### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,7 +45,7 @@ dnl Gettext
 AM_GNU_GETTEXT([external])
 
 dnl Headers, functions, and types
-AC_CHECK_HEADERS([sysexits.h netdb.h arpa/inet.h sys/socket.h sys/wait.h])
+AC_CHECK_HEADERS([sysexits.h netdb.h arpa/inet.h sys/socket.h sys/wait.h netinet/in.h])
 AC_CHECK_FUNCS([fmemopen fseeko fseeko64 getpass getservbyname link mkstemp signal strndup syslog vasprintf])
 AC_SEARCH_LIBS([nanosleep], [rt posix4])
 AC_SEARCH_LIBS([socket], [socket])

--- a/src/net.c
+++ b/src/net.c
@@ -43,6 +43,9 @@
 #ifdef HAVE_SYS_SOCKET_H
 # include <sys/socket.h>
 #endif
+#ifdef HAVE_NETINET_IN_H
+# include <netinet/in.h>
+#endif
 #ifdef HAVE_ARPA_INET_H
 # include <arpa/inet.h>
 #endif


### PR DESCRIPTION
Build on FreeBSD fails with:

```
  CC       net.o
net.c:317:25: error: variable has incomplete type 'struct sockaddr_in6'
    struct sockaddr_in6 sa6;
                        ^
net.c:317:12: note: forward declaration of 'struct sockaddr_in6'
    struct sockaddr_in6 sa6;
           ^
net.c:318:24: error: variable has incomplete type 'struct sockaddr_in'
    struct sockaddr_in sa4;
                       ^
net.c:318:12: note: forward declaration of 'struct sockaddr_in'
    struct sockaddr_in sa4;
           ^
2 errors generated.
```

Need to include <netinet/in.h> to fix that.