### PR TITLE
Fix OAUTHBEARER authentication

### DIFF
--- a/src/msmtp.c
+++ b/src/msmtp.c
@@ -284,7 +284,8 @@ int msmtp_rmqs(account_t *acc, int debug, const char *rmqs_argument,
             msmtp_endsession(&srv, 1);
             return EX_UNAVAILABLE;
         }
-        if ((e = smtp_auth(&srv, acc->host, acc->username, acc->password,
+        if ((e = smtp_auth(&srv, acc->host, acc->port,
+                        acc->username, acc->password,
                         acc->ntlmdomain, acc->auth_mech,
                         msmtp_password_callback, msg, errstr))
                 != SMTP_EOK)
@@ -1447,7 +1448,8 @@ int msmtp_sendmail(account_t *acc, list_t *recipients,
             e = EX_UNAVAILABLE;
             return e;
         }
-        if ((e = smtp_auth(&srv, acc->host, acc->username, acc->password,
+        if ((e = smtp_auth(&srv, acc->host, acc->port,
+                        acc->username, acc->password,
                         acc->ntlmdomain, acc->auth_mech,
                         msmtp_password_callback, msg, errstr))
                 != SMTP_EOK)

--- a/src/smtp.h
+++ b/src/smtp.h
@@ -251,6 +251,8 @@ int smtp_server_supports_authmech(smtp_server_t *srv, const char *mech);
  * SMTP_EINSECURE.
  * The hostname is the name of the SMTP server. It may be needed for
  * authentication.
+ * The port is port number SMTP server accepts connections on. It may be needed
+ * for authentication.
  * The ntlmdomain may be NULL (even if you use NTLM authentication).
  * If 'password' is NULL, but the authentication method needs a password,
  * the 'password_callback' function is called (if 'password_callback' is not
@@ -262,6 +264,7 @@ int smtp_server_supports_authmech(smtp_server_t *srv, const char *mech);
  */
 int smtp_auth(smtp_server_t *srv,
         const char *hostname,
+        unsigned short port,
         const char *user,
         const char *password,
         const char *ntlmdomain,


### PR DESCRIPTION
When using OAUTHBEARER we can't simply pass authentication token into
the AUTH command like XOAUTH2 allowed us to do, but we need to format
it as:

	n,a=<username>,^Ahost=<hostname>^Aport=<port>
	^Aauth=Bearer <token>^A^A

and base64-encode the resulting string before passing it to AUTH
OAUTHBEARER command.

With this change I can successfully authenticate against Gmail using the bearer
token instead of application-specific password.