### PR TITLE
Update --read-envelope-from description

### DIFF
--- a/doc/msmtp.1
+++ b/doc/msmtp.1
@@ -177,8 +177,6 @@ Resent-Cc, and Resent-Bcc headers in the first block of Resent- headers are
 used instead.
 .IP "\-\-read\-envelope\-from"
 Read the envelope from address from the From header of the mail.
-Currently this header must be on a single line for this option to work
-correctly.
 .IP "\-\-aliases=[\fIfile\fP]"
 Set or unset an aliases file. See the \fBaliases\fP command.
 .IP "\-F\fIname\fP"


### PR DESCRIPTION
Testing with 1.6.6 shows, that option "--read-envelope-from" works with multi-line "From:" headers.