### PR TITLE
msmtpq: Don't show "headers" from the body in the list

### DIFF
--- a/scripts/msmtpq/msmtpq
+++ b/scripts/msmtpq/msmtpq
@@ -334,7 +334,7 @@ display_queue() {      # <-- { 'purge' | 'send' } (op label) ; { 'rec' } (record
       ID="$(basename $M .mail)"      # take mail id from filename
       CNT=$((CNT + 1))
       dsp '' "mail  num=[ $CNT ]  id=[ $ID ]"                  # show mail id ## patch in
-      'grep' -E -s --colour -h '(^From:|^To:|^Subject:)' "$M"    # show mail info
+      'grep' -E -s --colour=always -h '(^From:|^To:|^Subject:)' "$M" | head -n 3 # show mail info
       [ -n "$2" ] && Q_LST[$CNT]="$ID" # bang mail id into array (note 1-based array indexing)
     done
     echo

--- a/scripts/msmtpqueue/msmtp-listqueue.sh
+++ b/scripts/msmtpqueue/msmtp-listqueue.sh
@@ -3,6 +3,7 @@
 QUEUEDIR=$HOME/.msmtpqueue
 
 for i in $QUEUEDIR/*.mail; do
-	grep -E -s --colour -h '(^From:|^To:|^Subject:)' "$i" || echo "No mail in queue";
+	HEADERS=$(grep -E -s --colour=always -h '(^From:|^To:|^Subject:)' "$i" || echo "No mail in queue")
+	echo "$HEADERS" | head -n 3 # Limited to three rows to avoid matches from the body.
 	echo " "
 done


### PR DESCRIPTION
If a mail's body contained lines that start with "From:", "To:", or
"Subject:" those used to be shown in msmtp-queue as well.

While this change is still not 100% accurate, it should work well enough
(all three headers must be present exactly once before the body begins).

---

An example:
![image](https://user-images.githubusercontent.com/7537109/80311525-6c712580-87e0-11ea-87df-e36eb781ce2e.png)

Note regarding `grep`: I hope the parameter `always` is portable, but since the `--colour` parameter isn't part of the POSIX standard the script might require GNU grep anyway.

Feel free to change the implementation if you want, this is just a suggestion ;)