### PR TITLE
[nix] Add nix derivation for static builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ src/*.obj
 src/msmtp
 src/msmtp.exe
 stamp-h1
+result

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,29 @@
+{ system ? builtins.currentSystem }:
+let
+  pkgs = (import ./nixpkgs.nix {}).pkgsStatic;
+
+  self = with pkgs; stdenv.mkDerivation rec {
+    name = "msmtmp";
+    src = ./..;
+    doCheck = false;
+    enableParallelBuilding = true;
+    nativeBuildInputs = [ autoreconfHook gettext pkg-config texinfo ];
+    buildInputs = [ openssl ];
+    configureFlags = [
+      "--prefix=/usr"
+	  "--sysconfdir=/etc"
+	  "--mandir=/usr/share/man"
+	  "--localstatedir=/var"
+      "--with-tls=openssl"
+      "--with-msmtpd"
+    ];
+    prePatch = ''
+      export LDFLAGS='-static -s -w'
+      export EXTRA_LDFLAGS='-s -w -linkmode external -extldflags "-static -lm"'
+    '';
+    installPhase = ''
+      install -Dm755 src/msmtp $out/bin/msmtp
+      install -Dm755 src/msmtpd $out/bin/msmtpd
+    '';
+  };
+in self

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,0 +1,10 @@
+{
+  "url": "https://github.com/nixos/nixpkgs",
+  "rev": "0f114432d4a9399e0b225d5be1599c7ebc5e2772",
+  "date": "2020-05-29T19:54:08-05:00",
+  "path": "/nix/store/ds31sjj3ppsk0xclkficx9p3w6qslmdc-nixpkgs",
+  "sha256": "1qd2dlc5dk98y0xdahv9k72ibv5dsy10jg25xqvj38sadxbs3g0j",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,0 +1,8 @@
+let
+  json = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
+  nixpkgs = import (builtins.fetchTarball {
+    name = "nixos-unstable";
+    url = "${json.url}/archive/${json.rev}.tar.gz";
+    inherit (json) sha256;
+  });
+in nixpkgs


### PR DESCRIPTION
Utilize nix's `.pkgsStatic` for musl based statically linked binary.

Replacing gnutls with openssl for better musl support.

`msmtp --version` with following result:

```
msmtp version 1.8.10
Platform: x86_64-unknown-linux-musl
TLS/SSL library: OpenSSL
Authentication library: built-in
Supported authentication methods:
plain external cram-md5 login oauthbearer
IDN support: disabled
NLS: enabled, LOCALEDIR is /usr/share/locale
Keyring support: none
System configuration file name: /etc/msmtprc
User configuration file name: /home/hswong3i/.msmtprc

Copyright (C) 2020 Martin Lambers and others.
This is free software.  You may redistribute copies of it under the terms of
the GNU General Public License <http://www.gnu.org/licenses/gpl.html>.
There is NO WARRANTY, to the extent permitted by law.
```

Signed-off-by: Wong Hoi Sing Edison <hswong3i@gmail.com>