### PR TITLE
Add missing sys/wait.h include

### DIFF
--- a/src/msmtpd.c
+++ b/src/msmtpd.c
@@ -33,6 +33,7 @@
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
+#include <sys/wait.h>
 #include <getopt.h>
 extern char *optarg;
 extern int optind;


### PR DESCRIPTION
Build on FreeBSD fails with:

  CCLD     msmtpd
ld: error: undefined symbol: WIFEXITED
>>> referenced by msmtpd.c:299
>>>               msmtpd.o:(msmtpd_session)

ld: error: undefined symbol: WEXITSTATUS
>>> referenced by msmtpd.c:302
>>>               msmtpd.o:(msmtpd_session)
>>> referenced by msmtpd.c:303
>>>               msmtpd.o:(msmtpd_session)
cc: error: linker command failed with exit code 1 (use -v to see invocation)
gmake[2]: *** [Makefile:431: msmtpd] Error 1

Before that, warnings "implicit declaration of functio" for WIFEXITED and
WEXITSTATUS are emitted.

Fix by including <sys/wait.h>.