### PR TITLE
msmtpq: Restore old default connection test

### DIFF
--- a/scripts/msmtpq/msmtpq
+++ b/scripts/msmtpq/msmtpq
@@ -108,7 +108,6 @@ LOG=~/log/msmtp.queue.log
 ##
 #EMAIL_CONN_NOTEST=y                 # deprecated ; use below var
 #EMAIL_CONN_TEST={x| |p|P|n|s}       # see settings above for EMAIL_CONN_TEST
-EMAIL_CONN_TEST=n
 #EMAIL_QUEUE_QUIET=t
 ## ======================================================================================
 


### PR DESCRIPTION
716e47e (New version of msmtpq script, 2013-02-14) added the
connect_test() function. By setting EMAIL_CONN_TEST, the user could
select how connect_test() would check for a working Internet connection.
If the user didn’t specify EMAIL_CONN_TEST, then connect_test() would
use ping by default.

0f794b7 (Update msmtpq scripts., 2015-03-12) added [a line that sets
EMAIL_CONN_TEST to “n”][to-n]. This means two things:

1. The default connection test is no longer the one that uses ping, but
the comments in connect_test() still say that it’s the default.
2. The only way to switch to a different connection test is to edit the
msmtpq script itself.

Considering the number of changes in that commit and its brief commit
message, it seems like that change was unintentional.

This commit makes the connection test that uses ping the default again
and allows users to choose a different test without modifying the msmtpq
script itself.

[to-n]: https://github.com/marlam/msmtp-mirror/commit/0f794b730a178b6ea7899b9f1484b8ae13f64e77#diff-8d6b6177fe17f5abb81fbccf4c37d52e980f58589f089a9c3649ba4fd56f6a62R111