### PR TITLE
msmtpq: changes from nixpkgs pull request

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,7 +24,7 @@ dnl Process this file with autoconf to produce a configure script.
 #
 
 dnl Autotools init stuff
-AC_INIT([msmtp],[1.8.20],[marlam@marlam.de],[msmtp],[https://marlam.de/msmtp])
+AC_INIT([msmtp],[1.8.21],[marlam@marlam.de],[msmtp],[https://marlam.de/msmtp])
 AC_CONFIG_SRCDIR([src/msmtp.c])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([config.h])

--- a/doc/msmtprc-system.example
+++ b/doc/msmtprc-system.example
@@ -8,7 +8,7 @@ account default
 # The SMTP smarthost
 host mail.oursite.example
 
-# Use TLS on port 465
+# Use TLS on port 465. On this port, TLS starts without STARTTLS.
 port 465
 tls on
 tls_starttls off

--- a/doc/msmtprc-user.example
+++ b/doc/msmtprc-user.example
@@ -1,80 +1,54 @@
 # Example for a user configuration file ~/.msmtprc
-#
-# This file focusses on TLS and authentication. Features not used here include
-# logging, timeouts, SOCKS proxies, TLS parameters, Delivery Status Notification
-# (DSN) settings, and more.
 
+# With modern mail services that publish autoconfiguration information,
+# you can simply run 'msmtp --configure yourmail@example.com' to get
+# a basic working configuration.
 
-# Set default values for all following accounts.
+# This example focusses on TLS and authentication. Features not used here
+# include logging, timeouts, SOCKS proxies, TLS parameters, Delivery Status
+# Notification (DSN) settings, and more.
+
+# Set default values: use the mail submission port 587, and always use TLS.
+# On this port, TLS is activated via STARTTLS.
 defaults
-
-# Use the mail submission port 587 instead of the SMTP port 25.
 port 587
-
-# Always use TLS.
 tls on
+tls_starttls on
 
-# Set a list of trusted CAs for TLS. The default is to use system settings, but
-# you can select your own file.
-#tls_trust_file /etc/ssl/certs/ca-certificates.crt
-
-
-# A freemail service
+# Define a mail account at a freemail service
 account freemail
-
 # Host name of the SMTP server
 host smtp.freemail.example
-
-# As an alternative to tls_trust_file, you can use tls_fingerprint
-# to pin a single certificate. You have to update the fingerprint when the
-# server certificate changes, but an attacker cannot trick you into accepting
-# a fraudulent certificate. Get the fingerprint with
-# $ msmtp --serverinfo --tls --tls-certcheck=off --host=smtp.freemail.example
-#tls_fingerprint 00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33
-
 # Envelope-from address
 from joe_smith@freemail.example
-
 # Authentication. The password is given using one of five methods, see below.
 auth on
 user joe.smith
-
 # Password method 1: Add the password to the system keyring, and let msmtp get
-# it automatically. To set the keyring password using Gnome's libsecret:
+# it automatically. To set the keyring password using libsecret:
 # $ secret-tool store --label=msmtp \
 #   host smtp.freemail.example \
 #   service smtp \
 #   user joe.smith
-
 # Password method 2: Store the password in an encrypted file, and tell msmtp
 # which command to use to decrypt it. This is usually used with GnuPG, as in
 # this example. Usually gpg-agent will ask once for the decryption password.
 passwordeval gpg2 --no-tty -q -d ~/.msmtp-password.gpg
+# You can also store the password directly in this file or have msmtp ask you
+# for it each time you send a mail, but one of the above methods is preferred.
 
-# Password method 3: Store the password directly in this file. Usually it is not
-# a good idea to store passwords in cleartext files. If you do it anyway, at
-# least make sure that this file can only be read by yourself.
-#password secret123
-
-# Password method 4: Store the password in ~/.netrc. This method is probably not
-# relevant anymore.
-
-# Password method 5: Do not specify a password. Msmtp will then prompt you for
-# it. This means you need to be able to type into a terminal when msmtp runs.
-
-
-# A second mail address at the same freemail service
+# A second mail address at the same freemail service: it uses the same settings
+# and just changes the envelope from address
 account freemail2 : freemail
 from joey@freemail.example
 
-
-# The SMTP server of your ISP
-account isp
-host mail.isp.example
-from smithjoe@isp.example
+# Some other mail service
+account company
+host mail.company.example
+from smithjoe@company.example
 auth on
-user 12345
-
+user company12345
+# this assumes the password is stored in the keyring
 
 # Set a default account
 account default : freemail

--- a/doc/msmtprc-user.example
+++ b/doc/msmtprc-user.example
@@ -21,7 +21,7 @@ account freemail
 host smtp.freemail.example
 # Envelope-from address
 from joe_smith@freemail.example
-# Authentication. The password is given using one of five methods, see below.
+# Authentication
 auth on
 user joe.smith
 # Password method 1: Add the password to the system keyring, and let msmtp get

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: msmtp 1.8.14\n"
 "Report-Msgid-Bugs-To: marlam@marlam.de\n"
-"POT-Creation-Date: 2022-03-23 20:22+0100\n"
+"POT-Creation-Date: 2022-07-27 18:42+0200\n"
 "PO-Revision-Date: 2020-12-23 22:43+0100\n"
 "Last-Translator: Mario Blättermann <mario.blaettermann@gmail.com>\n"
 "Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
@@ -41,7 +41,7 @@ msgstr "Zeile %d: Ungültiges Argument %s für Befehl %s"
 msgid "line %d: duplicate alias '%s'"
 msgstr ""
 
-#: src/aliases.c:178 src/conf.c:1072 src/stream.c:63
+#: src/aliases.c:178 src/conf.c:1193 src/stream.c:63
 #, c-format
 msgid "input error"
 msgstr "Lesefehler"
@@ -51,32 +51,32 @@ msgstr "Lesefehler"
 msgid "Too many redirects when expanding alias %s."
 msgstr ""
 
-#: src/conf.c:808 src/conf.c:823
+#: src/conf.c:815 src/conf.c:830
 #, c-format
 msgid "host not set"
 msgstr "Host nicht angegeben"
 
-#: src/conf.c:813
+#: src/conf.c:820
 #, c-format
 msgid "port not set"
 msgstr "Port nicht angegeben"
 
-#: src/conf.c:818
+#: src/conf.c:825
 #, c-format
 msgid "envelope-from address is missing"
 msgstr "Umschlagabsenderadresse fehlt"
 
-#: src/conf.c:828
+#: src/conf.c:835
 #, c-format
 msgid "tls_key_file requires tls_cert_file"
 msgstr "tls_key_file benötigt tls_cert_file"
 
-#: src/conf.c:833
+#: src/conf.c:840
 #, c-format
 msgid "tls_cert_file requires tls_key_file"
 msgstr "tls_cert_file benötigt tls_key_file"
 
-#: src/conf.c:841
+#: src/conf.c:848
 #, c-format
 msgid ""
 "tls requires either tls_trust_file (highly recommended) or tls_fingerprint "
@@ -85,74 +85,74 @@ msgstr ""
 "TLS benötigt entweder tls_trust_file (empfohlen) oder tls_fingerprint oder "
 "ein abgeschaltetes tls_certcheck"
 
-#: src/conf.c:847
+#: src/conf.c:854
 #, c-format
 msgid "tls_crl_file requires tls_trust_file"
 msgstr "tls_crl_file benötigt tls_trust_file"
 
-#: src/conf.c:879 src/conf.c:886 src/conf.c:903 src/mtls-gnutls.c:328
+#: src/conf.c:886 src/conf.c:893 src/conf.c:910 src/mtls-gnutls.c:328
 #, c-format
 msgid "%s: %s"
 msgstr "%s: %s"
 
-#: src/conf.c:1094
-#, c-format
-msgid "line longer than %d characters"
-msgstr "Zeile länger als %d Zeichen"
-
-#: src/conf.c:1145 src/conf.c:1270
+#: src/conf.c:1119 src/conf.c:1292
 #, c-format
 msgid "line %d: missing account name"
 msgstr "Zeile %d: Kontenname fehlt"
 
-#: src/conf.c:1150
+#: src/conf.c:1124
 #, c-format
 msgid "line %d: account %s not (yet) defined"
 msgstr "Zeile %d: Konto %s ist (noch) nicht definiert"
 
-#: src/conf.c:1242 src/conf.c:2060 src/conf.c:2077
+#: src/conf.c:1205
+#, c-format
+msgid "line longer than %d characters"
+msgstr "Zeile länger als %d Zeichen"
+
+#: src/conf.c:1222 src/conf.c:1335 src/conf.c:1354 src/conf.c:1381
+#: src/conf.c:1410 src/conf.c:1718 src/conf.c:1753
+#, c-format
+msgid "line %d: command %s needs an argument"
+msgstr "Zeile %d: Befehl %s benötigt ein Argument"
+
+#: src/conf.c:1264 src/conf.c:2103 src/conf.c:2120
 #, c-format
 msgid "line %d: command %s does not take an argument"
 msgstr "Zeile %d: Befehl %s akzeptiert kein Argument"
 
-#: src/conf.c:1278
+#: src/conf.c:1300
 #, c-format
 msgid "line %d: an account name must not contain colons or commas"
 msgstr ""
 "Zeile %d: Ein Kontenname darf keine Doppelpunkte oder Kommata enthalten"
 
-#: src/conf.c:1288
+#: src/conf.c:1310
 #, c-format
 msgid "line %d: account %s was already defined"
 msgstr "Zeile %d: Konto %s wurde bereits definiert"
 
-#: src/conf.c:1313 src/conf.c:1332 src/conf.c:1359 src/conf.c:1388
-#: src/conf.c:1695 src/conf.c:1730
-#, c-format
-msgid "line %d: command %s needs an argument"
-msgstr "Zeile %d: Befehl %s benötigt ein Argument"
-
-#: src/conf.c:1343 src/conf.c:1375 src/conf.c:1406 src/conf.c:1440
-#: src/conf.c:1466 src/conf.c:1511 src/conf.c:1531 src/conf.c:1616
-#: src/conf.c:1637 src/conf.c:1656 src/conf.c:1717 src/conf.c:1748
-#: src/conf.c:1798 src/conf.c:1845 src/conf.c:1870 src/conf.c:1890
-#: src/conf.c:1910 src/conf.c:1930 src/conf.c:1977 src/conf.c:1998
-#: src/conf.c:2019 src/conf.c:2047
+#: src/conf.c:1365 src/conf.c:1397 src/conf.c:1428 src/conf.c:1462
+#: src/conf.c:1488 src/conf.c:1534 src/conf.c:1554 src/conf.c:1639
+#: src/conf.c:1660 src/conf.c:1679 src/conf.c:1740 src/conf.c:1771
+#: src/conf.c:1821 src/conf.c:1868 src/conf.c:1893 src/conf.c:1913
+#: src/conf.c:1933 src/conf.c:1953 src/conf.c:1973 src/conf.c:2020
+#: src/conf.c:2041 src/conf.c:2062 src/conf.c:2090
 #, c-format
 msgid "line %d: invalid argument %s for command %s"
 msgstr "Zeile %d: Ungültiges Argument %s für Befehl %s"
 
-#: src/conf.c:2093
+#: src/conf.c:2136
 #, c-format
 msgid "line %d: unknown command %s"
 msgstr "Zeile %d: Unbekannter Befehl %s"
 
-#: src/conf.c:2145
+#: src/conf.c:2190
 #, c-format
 msgid "contains secrets and therefore must be owned by you"
 msgstr "enthält Passwörter und muss daher Ihnen gehören"
 
-#: src/conf.c:2151
+#: src/conf.c:2196
 #, c-format
 msgid ""
 "contains secrets and therefore must have no more than user read/write "
@@ -163,101 +163,101 @@ msgstr ""
 
 #. TRANSLATORS: msmtp shares a lot of code and translatable strings with
 #. mpop <https://marlam.de/mpop>.
-#: src/msmtp.c:88
+#: src/msmtp.c:90
 #, c-format
 msgid "%s: FATAL: %s\n"
 msgstr "%s: FATAL: %s\n"
 
-#: src/msmtp.c:228 src/msmtp.c:406 src/msmtp.c:1401
+#: src/msmtp.c:230 src/msmtp.c:408 src/msmtp.c:1522
 #, c-format
 msgid "the server does not support TLS via the STARTTLS command"
 msgstr "der POP-Server unterstützt über den STLS-Befehl kein TLS"
 
-#: src/msmtp.c:270
+#: src/msmtp.c:272
 #, c-format
 msgid "the server does not support Remote Message Queue Starting"
 msgstr "der Server unterstützt »Remote Message Queue Starting« nicht"
 
-#: src/msmtp.c:282 src/msmtp.c:1459
+#: src/msmtp.c:284 src/msmtp.c:1580
 #, c-format
 msgid "the server does not support authentication"
 msgstr "der Server unterstützt keine Authentifizierung"
 
-#: src/msmtp.c:441
+#: src/msmtp.c:443
 #, c-format
 msgid "%s server at %s (%s [%s]), port %d:\n"
 msgstr "%s-Server auf %s (%s [%s]), Port %d:\n"
 
-#: src/msmtp.c:447
+#: src/msmtp.c:450
 #, c-format
 msgid "%s server at %s (%s), port %d:\n"
 msgstr "%s-Server auf %s (%s), Port %d:\n"
 
-#: src/msmtp.c:453
+#: src/msmtp.c:457
 #, c-format
 msgid "%s server at %s ([%s]), port %d:\n"
 msgstr "%s-Server auf %s ([%s]), Port %d:\n"
 
-#: src/msmtp.c:459
+#: src/msmtp.c:464
 #, c-format
 msgid "%s server at %s, port %d:\n"
 msgstr "%s-Server auf %s, Port %d:\n"
 
-#: src/msmtp.c:479
+#: src/msmtp.c:485
 #, c-format
 msgid "No special capabilities.\n"
 msgstr "Keine besonderen Leistungsmerkmale.\n"
 
-#: src/msmtp.c:483
+#: src/msmtp.c:489
 #, c-format
 msgid "Capabilities:\n"
 msgstr "Leistungsmerkmale:\n"
 
-#: src/msmtp.c:487
+#: src/msmtp.c:493
 msgid "Maximum message size is "
 msgstr "Maximale Mailgröße ist "
 
-#: src/msmtp.c:490
+#: src/msmtp.c:496
 #, c-format
 msgid "unlimited\n"
 msgstr "unbegrenzt\n"
 
-#: src/msmtp.c:494
+#: src/msmtp.c:500
 #, c-format
 msgid "%ld bytes"
 msgstr "%ld Byte"
 
-#: src/msmtp.c:497
+#: src/msmtp.c:503
 #, c-format
 msgid " = %.2f MiB"
 msgstr " = %.2f MiB"
 
-#: src/msmtp.c:502
+#: src/msmtp.c:508
 #, c-format
 msgid " = %.2f KiB"
 msgstr " = %.2f KiB"
 
-#: src/msmtp.c:509
+#: src/msmtp.c:515
 msgid "Support for command grouping for faster transmission"
 msgstr "Unterstützung für schnelle Übertragung durch Befehlsgruppierung"
 
-#: src/msmtp.c:514
+#: src/msmtp.c:520
 msgid "Support for RMQS (Remote Message Queue Starting)"
 msgstr "Unterstützung für RMQS (Remote Message Queue Starting)"
 
-#: src/msmtp.c:519
+#: src/msmtp.c:525
 msgid "Support for Delivery Status Notifications"
 msgstr "Unterstützung für Zustellstatusbenachrichtigungen (DSN)"
 
-#: src/msmtp.c:529
+#: src/msmtp.c:535
 msgid "Support for TLS encryption via the STARTTLS command"
 msgstr "Unterstützung für TLS-Verschlüsselung über den STLS-Befehl"
 
-#: src/msmtp.c:535
+#: src/msmtp.c:541
 msgid "Supported authentication methods:"
 msgstr "Unterstützte Authentifizierungsmethoden:"
 
-#: src/msmtp.c:588
+#: src/msmtp.c:594
 #, c-format
 msgid ""
 "This server might advertise more or other capabilities when TLS is active.\n"
@@ -265,115 +265,115 @@ msgstr ""
 "Dieser Server könnte mehr oder andere Leistungsmerkmale angeben,\n"
 "    wenn TLS-Verschlüsselung aktiviert ist.\n"
 
-#: src/msmtp.c:1153 src/msmtp.c:3299
+#: src/msmtp.c:1274 src/msmtp.c:3447
 #, c-format
 msgid "cannot write mail headers to temporary file: output error"
 msgstr ""
 "Mail-Kopfzeilen können nicht in temporäre Datei geschrieben werden: "
 "Ausgabefehler"
 
-#: src/msmtp.c:1261
+#: src/msmtp.c:1382
 #, c-format
 msgid "input error while reading the mail"
 msgstr "Fehler beim Lesen der Mail"
 
-#: src/msmtp.c:1448
+#: src/msmtp.c:1569
 #, c-format
 msgid "the server does not support DSN"
 msgstr "der Server unterstützt kein DSN"
 
-#: src/msmtp.c:1597 src/msmtp.c:1616 src/msmtp.c:1668
+#: src/msmtp.c:1718 src/msmtp.c:1737 src/msmtp.c:1789
 #, c-format
 msgid "automatic configuration based on SRV records failed: %s"
 msgstr ""
 "auf SRV-Datensätzen basierende automatische Konfiguration ist "
 "fehlgeschlagen: %s"
 
-#: src/msmtp.c:1598
+#: src/msmtp.c:1719
 msgid "invalid mail address"
 msgstr "ungültige E-Mail-Adresse"
 
-#: src/msmtp.c:1614
+#: src/msmtp.c:1735
 #, c-format
 msgid "no SRV records for %s or %s"
 msgstr "keine SRV-Datensätze für %s oder %s"
 
-#: src/msmtp.c:1631
+#: src/msmtp.c:1752
 #, c-format
 msgid "copy this to your configuration file %s"
 msgstr "dies zu Ihrer Konfigurationsdatei %s kopieren"
 
-#: src/msmtp.c:1635
+#: src/msmtp.c:1756
 msgid "warning: the host does not match the mail domain; please check"
 msgstr "Warnung: der Host passt nicht zur Mail-Domain; bitte prüfen"
 
-#: src/msmtp.c:1638 src/msmtp.c:1642
+#: src/msmtp.c:1759 src/msmtp.c:1763
 msgid "add your password to the key ring:"
 msgstr "Ihr Passwort zum Schlüsselbund hinzufügen:"
 
-#: src/msmtp.c:1645
+#: src/msmtp.c:1766
 msgid "encrypt your password:"
 msgstr "Ihr Passwort verschlüsseln:"
 
-#: src/msmtp.c:1669
+#: src/msmtp.c:1790
 msgid "this system lacks libresolv"
 msgstr "auf diesem System fehlt libresolv"
 
-#: src/msmtp.c:1896
+#: src/msmtp.c:2022
 #, c-format
 msgid "invalid logfile_time_format"
 msgstr "ungültiges logfile_time_format"
 
-#: src/msmtp.c:1909
+#: src/msmtp.c:2035
 #, c-format
 msgid "cannot open: %s"
 msgstr "kann nicht geöffnet werden: %s"
 
-#: src/msmtp.c:1917
+#: src/msmtp.c:2043
 #, c-format
 msgid "cannot lock (tried for %d seconds): %s"
 msgstr "kann nicht gesperrt werden (wurde %d Sekunden lang versucht): %s"
 
-#: src/msmtp.c:1922
+#: src/msmtp.c:2048
 #, c-format
 msgid "cannot lock: %s"
 msgstr "kann nicht gesperrt werden: %s"
 
-#: src/msmtp.c:1931
+#: src/msmtp.c:2057
 msgid "output error"
 msgstr "Ausgabefehler"
 
-#: src/msmtp.c:1948
+#: src/msmtp.c:2074
 #, c-format
 msgid "cannot log to %s: %s"
 msgstr "Protokollinformation kann nicht in %s geschrieben werden: %s"
 
-#: src/msmtp.c:1952
+#: src/msmtp.c:2078
 #, c-format
 msgid "log info was: %s"
 msgstr "Protokollinformation war: %s"
 
-#: src/msmtp.c:2061
+#: src/msmtp.c:2187
 #, c-format
 msgid "%s version %s\n"
 msgstr "%s Version %s\n"
 
-#: src/msmtp.c:2062
+#: src/msmtp.c:2188
 #, c-format
 msgid "Platform: %s\n"
 msgstr "Plattform: %s\n"
 
-#: src/msmtp.c:2064
+#: src/msmtp.c:2190
 #, c-format
 msgid "TLS/SSL library: %s\n"
 msgstr "TLS/SSL-Programmbibliothek: %s\n"
 
-#: src/msmtp.c:2072 src/msmtp.c:2150
+#: src/msmtp.c:2198 src/msmtp.c:2276
 #, c-format
 msgid "none"
 msgstr "keine"
 
-#: src/msmtp.c:2076
+#: src/msmtp.c:2202
 #, c-format
 msgid ""
 "Authentication library: %s\n"
@@ -382,65 +382,65 @@ msgstr ""
 "Authentifizierungsprogrammbibliothek: %s\n"
 "Unterstützte Authentifizierungsmethoden:\n"
 
-#: src/msmtp.c:2079
+#: src/msmtp.c:2205
 msgid "GNU SASL; oauthbearer and xoauth2: built-in"
 msgstr "GNU SASL; oauthbearer und xoauth2: eingebaut"
 
-#: src/msmtp.c:2081
+#: src/msmtp.c:2207
 msgid "built-in"
 msgstr "eingebaut"
 
-#: src/msmtp.c:2130
+#: src/msmtp.c:2256
 #, c-format
 msgid "IDN support: "
 msgstr "IDN-Unterstützung: "
 
-#: src/msmtp.c:2134 src/msmtp.c:2142
+#: src/msmtp.c:2260 src/msmtp.c:2268
 #, c-format
 msgid "enabled"
 msgstr "aktiviert"
 
-#: src/msmtp.c:2136 src/msmtp.c:2145
+#: src/msmtp.c:2262 src/msmtp.c:2271
 #, c-format
 msgid "disabled"
 msgstr "deaktiviert"
 
-#: src/msmtp.c:2140
+#: src/msmtp.c:2266
 #, c-format
 msgid "NLS: "
 msgstr "NLS: "
 
-#: src/msmtp.c:2143
+#: src/msmtp.c:2269
 #, c-format
 msgid ", LOCALEDIR is %s"
 msgstr ", LOCALEDIR ist %s"
 
-#: src/msmtp.c:2148
+#: src/msmtp.c:2274
 #, c-format
 msgid "Keyring support: "
 msgstr "Schlüsselbund-Unterstützung: "
 
-#: src/msmtp.c:2153
+#: src/msmtp.c:2279
 #, c-format
 msgid "Gnome "
 msgstr "Gnome "
 
-#: src/msmtp.c:2156
+#: src/msmtp.c:2282
 #, c-format
 msgid "MacOS "
 msgstr "MacOS "
 
-#: src/msmtp.c:2162
+#: src/msmtp.c:2288
 #, c-format
 msgid "System configuration file name: %s\n"
 msgstr "Systemweite Konfigurationsdatei: %s\n"
 
-#: src/msmtp.c:2166
+#: src/msmtp.c:2292
 #, c-format
 msgid "User configuration file name: %s\n"
 msgstr "Benutzerkonfigurationsdatei: %s\n"
 
-#: src/msmtp.c:2169
+#: src/msmtp.c:2295
 #, fuzzy, c-format
 #| msgid ""
 #| "Copyright (C) 2020 Martin Lambers and others.\n"
@@ -461,7 +461,7 @@ msgstr ""
 "der GNU General Public License <http://www.gnu.org/licenses/gpl.html>.\n"
 "Es gibt KEINERLEI GARANTIE, so weit das Gesetz es erlaubt.\n"
 
-#: src/msmtp.c:2186
+#: src/msmtp.c:2312
 #, c-format
 msgid ""
 "Usage:\n"
@@ -470,7 +470,7 @@ msgstr ""
 "Aufruf:\n"
 "\n"
 
-#: src/msmtp.c:2187
+#: src/msmtp.c:2313
 #, c-format
 msgid ""
 "Sendmail mode (default):\n"
@@ -485,7 +485,7 @@ msgstr ""
 "  Mail von Standardeingabe lesen und sie zu einem SMTP-\n"
 "  oder LMTP-Server übertragen.\n"
 
-#: src/msmtp.c:2192
+#: src/msmtp.c:2318
 #, c-format
 msgid ""
 "Configuration mode:\n"
@@ -496,7 +496,7 @@ msgstr ""
 "  %s --configure=E-Mail-Adresse\n"
 "  Konfiguration für die Adresse erstellen und ausgeben.\n"
 
-#: src/msmtp.c:2195
+#: src/msmtp.c:2321
 #, c-format
 msgid ""
 "Server information mode:\n"
@@ -507,7 +507,7 @@ msgstr ""
 "  %s [Option…] --serverinfo\n"
 "  Informationen zu einem Server anzeigen.\n"
 
-#: src/msmtp.c:2198
+#: src/msmtp.c:2324
 #, c-format
 msgid ""
 "Remote Message Queue Starting mode:\n"
@@ -520,66 +520,66 @@ msgstr ""
 "  Eine RMQS-Anfrage an einen Server senden.\n"
 "\n"
 
-#: src/msmtp.c:2202
+#: src/msmtp.c:2328
 #, c-format
 msgid "General options:\n"
 msgstr "Allgemeine Optionen:\n"
 
-#: src/msmtp.c:2203
+#: src/msmtp.c:2329
 #, c-format
 msgid "  --version                    print version\n"
 msgstr "  --version                    Version anzeigen\n"
 
-#: src/msmtp.c:2204
+#: src/msmtp.c:2330
 #, c-format
 msgid "  --help                       print help\n"
 msgstr "  --help                       Hilfetext anzeigen\n"
 
-#: src/msmtp.c:2205
+#: src/msmtp.c:2331
 #, c-format
 msgid "  -P, --pretend                print configuration info and exit\n"
 msgstr "  -P, --pretend                Konfiguration anzeigen und beenden\n"
 
-#: src/msmtp.c:2206
+#: src/msmtp.c:2332
 #, c-format
 msgid "  -d, --debug                  print debugging information\n"
 msgstr ""
 "  -d, --debug                  Debugging-Information anzeigen und beenden\n"
 
-#: src/msmtp.c:2207
+#: src/msmtp.c:2333
 #, c-format
 msgid "Changing the mode of operation:\n"
 msgstr "Operationsmodus wechseln:\n"
 
-#: src/msmtp.c:2208
+#: src/msmtp.c:2334
 #, c-format
 msgid ""
 "  --configure=mailaddress      generate and print configuration for address\n"
 msgstr "  -C, --file=Dateiname         Konfigurationsdatei festlegen\n"
 
-#: src/msmtp.c:2209
+#: src/msmtp.c:2335
 #, c-format
 msgid "  -S, --serverinfo             print information about the server\n"
 msgstr ""
 "  -S, --serverinfo             Informationen zu einem Server anzeigen\n"
 
-#: src/msmtp.c:2210
+#: src/msmtp.c:2336
 #, c-format
 msgid ""
 "  --rmqs=host|@domain|#queue   send a Remote Message Queue Starting request\n"
 msgstr "  --rmqs=host|@domain|#queue   eine RMQS-Anfrage senden\n"
 
-#: src/msmtp.c:2211
+#: src/msmtp.c:2337
 #, c-format
 msgid "Configuration options:\n"
 msgstr "Konfigurationsoptionen:\n"
 
-#: src/msmtp.c:2212
+#: src/msmtp.c:2338
 #, c-format
 msgid "  -C, --file=filename          set configuration file\n"
 msgstr "  -C, --file=Dateiname         Konfigurationsdatei festlegen\n"
 
-#: src/msmtp.c:2213
+#: src/msmtp.c:2339
 #, c-format
 msgid ""
 "  -a, --account=id             use the given account instead of the account\n"
@@ -592,7 +592,7 @@ msgstr ""
 "können\n"
 "                               über die Befehlszeile geändert werden\n"
 
-#: src/msmtp.c:2216
+#: src/msmtp.c:2342
 #, c-format
 msgid ""
 "  --host=hostname              set the server, use only command-line "
@@ -603,12 +603,12 @@ msgstr ""
 "nutzen;\n"
 "                               keine Konfigurationsdatei benutzen\n"
 
-#: src/msmtp.c:2218
+#: src/msmtp.c:2344
 #, c-format
 msgid "  --port=number                set port number\n"
 msgstr "  --port=Nummer                Portnummer festlegen\n"
 
-#: src/msmtp.c:2219
+#: src/msmtp.c:2345
 #, c-format
 msgid ""
 "  --source-ip=[IP]             set/unset source ip address to bind the "
@@ -617,36 +617,36 @@ msgstr ""
 "  --source-ip=[IP]             Quell-IP-Adresse für Verbindung setzen/"
 "löschen \n"
 
-#: src/msmtp.c:2220
+#: src/msmtp.c:2346
 #, c-format
 msgid "  --proxy-host=[IP|hostname]   set/unset proxy\n"
 msgstr "  --proxy-host=[IP|Hostname]   Proxy festlegen/löschen\n"
 
-#: src/msmtp.c:2221
+#: src/msmtp.c:2347
 #, c-format
 msgid "  --proxy-port=[number]        set/unset proxy port\n"
 msgstr "  --proxy-port=[Nummer]        Proxy-Port setzen/löschen\n"
 
-#: src/msmtp.c:2222
+#: src/msmtp.c:2348
 #, c-format
 msgid "  --socket=[socketname]        set/unset local socket to connect to\n"
 msgstr ""
 "  --socket=[Socket-Name]        Lokalen Socket für die Verbindung festlegen/"
 "löschen\n"
 
-#: src/msmtp.c:2223
+#: src/msmtp.c:2349
 #, c-format
 msgid "  --timeout=(off|seconds)      set/unset network timeout in seconds\n"
 msgstr ""
 "  --timeout=(off|Sekunden)     Zeitüberschreitung in Sekunden setzen/"
 "löschen \n"
 
-#: src/msmtp.c:2224
+#: src/msmtp.c:2350
 #, c-format
 msgid "  --protocol=(smtp|lmtp)       use the given sub protocol\n"
 msgstr "  --protocol=(smtp|lmtp)       Das angegebene Unterprotokoll nutzen\n"
 
-#: src/msmtp.c:2225
+#: src/msmtp.c:2351
 #, c-format
 msgid ""
 "  --domain=string              set the argument of EHLO or LHLO command\n"
@@ -654,7 +654,7 @@ msgstr ""
 "  --domain=Zeichenkette        Das Argument des EHLO- oder LHLO-Befehls\n"
 "                               angeben\n"
 
-#: src/msmtp.c:2226
+#: src/msmtp.c:2352
 #, c-format
 msgid ""
 "  --auth[=(on|off|method)]     enable/disable authentication and optionally\n"
@@ -663,44 +663,44 @@ msgstr ""
 "  --auth[=(on|off|Methode)]     Authentifizierung aktivieren/deaktivieren\n"
 "                                und optional die Methode festlegen\n"
 
-#: src/msmtp.c:2228
+#: src/msmtp.c:2354
 #, c-format
 msgid "  --user=[username]            set/unset user name for authentication\n"
 msgstr ""
 "  --user=[Benutzername]        Benutzername für Authentifizierung festlegen/"
 "löschen\n"
 
-#: src/msmtp.c:2229
+#: src/msmtp.c:2355
 #, c-format
 msgid "  --passwordeval=[eval]        evaluate password for authentication\n"
 msgstr ""
 "  --passwordeval=[eval]        Passwort für Authentifizierung bewerten\n"
 
-#: src/msmtp.c:2230
+#: src/msmtp.c:2356
 #, c-format
 msgid "  --tls[=(on|off)]             enable/disable TLS encryption\n"
 msgstr ""
 "  --tls[=(on|off)]             TLS-Verschlüsselung aktivieren/deaktivieren\n"
 
-#: src/msmtp.c:2231
+#: src/msmtp.c:2357
 #, c-format
 msgid "  --tls-starttls[=(on|off)]    enable/disable STARTTLS for TLS\n"
 msgstr ""
 "  --tls-starttls[=(on|off)]    STARTTLS für TLS aktivieren/deaktivieren\n"
 
-#: src/msmtp.c:2232
+#: src/msmtp.c:2358
 #, c-format
 msgid "  --tls-trust-file=[file]      set/unset trust file for TLS\n"
 msgstr ""
 "  --tls-trust-file=[Datei]     Vertrauensdatei für TLS festlegen/löschen\n"
 
-#: src/msmtp.c:2233
+#: src/msmtp.c:2359
 #, c-format
 msgid "  --tls-crl-file=[file]        set/unset revocation file for TLS\n"
 msgstr ""
 "  --tls-crl-file=[Datei]       Widerrufsdatei für TLS festlegen/löschen\n"
 
-#: src/msmtp.c:2234
+#: src/msmtp.c:2360
 #, c-format
 msgid ""
 "  --tls-fingerprint=[f]        set/unset trusted certificate fingerprint for "
@@ -709,7 +709,7 @@ msgstr ""
 "  --tls-fingerprint=[f]        Zertifikatsfingerabdruck für TLS festlegen/"
 "löschen\n"
 
-#: src/msmtp.c:2235
+#: src/msmtp.c:2361
 #, c-format
 msgid ""
 "  --tls-certcheck[=(on|off)]   enable/disable server certificate checks for "
@@ -718,26 +718,26 @@ msgstr ""
 "  --tls-certcheck[=(on|off)]   Server-Zertifikatsüberprüfungen für TLS\n"
 "                               aktivieren/deaktivieren\n"
 
-#: src/msmtp.c:2236
+#: src/msmtp.c:2362
 #, c-format
 msgid "  --tls-key-file=[file]        set/unset private key file for TLS\n"
 msgstr ""
 "  --tls-key-file=[Datei]       Private Schlüsseldatei für TLS setzen/"
 "löschen\n"
 
-#: src/msmtp.c:2237
+#: src/msmtp.c:2363
 #, c-format
 msgid "  --tls-cert-file=[file]       set/unset private cert file for TLS\n"
 msgstr ""
 "  --tls-cert-file=[Datei]      Private Zertifikatsdatei für TLS festlegen/"
 "löschen\n"
 
-#: src/msmtp.c:2238
+#: src/msmtp.c:2364
 #, c-format
 msgid "  --tls-priorities=[prios]     set/unset TLS priorities.\n"
 msgstr "  --tls-priorities=[prios]     TLS-Prioritäten setzen/löschen\n"
 
-#: src/msmtp.c:2239
+#: src/msmtp.c:2365
 #, c-format
 msgid ""
 "  --tls-host-override=[host]   set/unset override for TLS host "
@@ -746,19 +746,19 @@ msgstr ""
 "  --tls-host-override=[host]   Außerkraftsetzung für TLS-Host-Verifizierung\n"
 "                                 setzen/löschen\n"
 
-#: src/msmtp.c:2240
+#: src/msmtp.c:2366
 #, c-format
 msgid "  --tls-min-dh-prime-bits=[b]  set/unset minimum bit size of DH prime\n"
 msgstr ""
 "  --tls-min-dh-prime-bits=[b]  Minimale Bitzahl für DH-Primzahl\n"
 "                               festlegen/löschen\n"
 
-#: src/msmtp.c:2241
+#: src/msmtp.c:2367
 #, c-format
 msgid "Options specific to sendmail mode:\n"
 msgstr "Optionen für den Sendmail-Modus:\n"
 
-#: src/msmtp.c:2242
+#: src/msmtp.c:2368
 #, c-format
 msgid ""
 "  --auto-from[=(on|off)]       enable/disable automatic envelope-from "
@@ -767,12 +767,12 @@ msgstr ""
 "  --auto-from[=(on|off)]       Automatische Umschlags-Absenderadresse\n"
 "                               aktivieren/deaktivieren\n"
 
-#: src/msmtp.c:2243
+#: src/msmtp.c:2369
 #, c-format
 msgid "  -f, --from=address           set envelope from address\n"
 msgstr "  -f, --from=address           Umschlags-Absenderadresse festlegen\n"
 
-#: src/msmtp.c:2244
+#: src/msmtp.c:2370
 #, c-format
 msgid ""
 "  --maildomain=[domain]        set the domain for automatic envelope from\n"
@@ -781,22 +781,22 @@ msgstr ""
 "  --maildomain=[Domain]        Domain für automatische Umschlags-\n"
 "                               Absenderadresse festlegen\n"
 
-#: src/msmtp.c:2246
+#: src/msmtp.c:2372
 #, c-format
 msgid "  -N, --dsn-notify=(off|cond)  set/unset DSN conditions\n"
 msgstr "  -N, --dsn-notify=(off|Bed.)  DSN-Bedingungen festlegen/löschen\n"
 
-#: src/msmtp.c:2247
+#: src/msmtp.c:2373
 #, c-format
 msgid "  -R, --dsn-return=(off|ret)   set/unset DSN amount\n"
 msgstr "  -R, --dsn-return=(off|Ant.)  DSN-Anteil setzen/löschen\n"
 
-#: src/msmtp.c:2248
+#: src/msmtp.c:2374
 #, c-format
 msgid "  -X, --logfile=[file]         set/unset log file\n"
 msgstr "  -X, --logfile=[Datei]        Protokolldatei festlegen löschen\n"
 
-#: src/msmtp.c:2249
+#: src/msmtp.c:2375
 #, c-format
 msgid ""
 "  --logfile-time-format=[fmt]  set/unset log file time format for "
@@ -805,7 +805,7 @@ msgstr ""
 "  --logfile-time-format=[Fmt.]  Protokolldatei-Zeitformat für strftime()\n"
 "                                festlegen/löschen\n"
 
-#: src/msmtp.c:2250
+#: src/msmtp.c:2376
 #, c-format
 msgid ""
 "  --syslog[=(on|off|facility)] enable/disable/configure syslog logging\n"
@@ -813,36 +813,43 @@ msgstr ""
 "  --syslog[=(on|off|Leistung)] Systemprotokollierung aktivieren/\n"
 "                               deaktivieren oder konfigurieren\n"
 
-#: src/msmtp.c:2251
+#: src/msmtp.c:2377
 #, c-format
 msgid ""
 "  -t, --read-recipients        read additional recipients from the mail\n"
 msgstr "  -t, --read-recipients        Weitere Empfänger aus der Mail lesen\n"
 
-#: src/msmtp.c:2252
+#: src/msmtp.c:2378
 #, c-format
 msgid ""
 "  --read-envelope-from         read envelope from address from the mail\n"
 msgstr "  --read-envelope-from         Umschlags-Absender aus der Mail lesen\n"
 
-#: src/msmtp.c:2253
+#: src/msmtp.c:2379
 #, c-format
 msgid "  --aliases=[file]             set/unset aliases file\n"
 msgstr "  --aliases=[Datei]            Aliasdatei festlegen/löschen\n"
 
-#: src/msmtp.c:2254
+#: src/msmtp.c:2380
 #, c-format
 msgid "  --set-from-header[=(auto|on|off)] set From header handling\n"
 msgstr ""
 "  --set-from-header[=(auto|on|off)] Umgang mit »From:«-Feldern festlegen\n"
 
-#: src/msmtp.c:2255
+#: src/msmtp.c:2381
 #, c-format
 msgid "  --set-date-header[=(auto|off)] set Date header handling\n"
 msgstr ""
 "  --set-date-header[=(auto|off)] Umgang mit »Date:«-Feldern festlegen\n"
 
-#: src/msmtp.c:2256
+#: src/msmtp.c:2382
+#, fuzzy, c-format
+#| msgid "  --set-date-header[=(auto|off)] set Date header handling\n"
+msgid "  --set-msgid-header[=(auto|off)] set Message-ID header handling\n"
+msgstr ""
+"  --set-date-header[=(auto|off)] Umgang mit »Date:«-Feldern festlegen\n"
+
+#: src/msmtp.c:2383
 #, c-format
 msgid ""
 "  --remove-bcc-headers[=(on|off)] enable/disable removal of Bcc headers\n"
@@ -850,7 +857,7 @@ msgstr ""
 "  --remove-bcc-headers[=(on|off)] Löschen von »Bcc:«\n"
 "                                  aktivieren/deaktivieren\n"
 
-#: src/msmtp.c:2257
+#: src/msmtp.c:2384
 #, c-format
 msgid ""
 "  --undisclosed-recipients[=(on|off)] enable/disable replacement of To/Cc/"
@@ -860,12 +867,12 @@ msgstr ""
 "  --undisclosed-recipients[=(on|off)] Ersetzung von To/Cc/Bcc durch\n"
 "                               To: undisclosed-recipients:; aktivieren\n"
 
-#: src/msmtp.c:2259
+#: src/msmtp.c:2386
 #, c-format
 msgid "  --                           end of options\n"
 msgstr "  --                           Ende der Optionen\n"
 
-#: src/msmtp.c:2260
+#: src/msmtp.c:2387
 #, c-format
 msgid ""
 "Accepted but ignored: -A, -B, -bm, -F, -G, -h, -i, -L, -m, -n, -O, -o, -v\n"
@@ -873,7 +880,7 @@ msgstr ""
 "Akzeptiert, aber ignoriert: -A, -B, -bm, -F, -G, -h, -i, -L, -m, -n, -O, -o, "
 "-v\n"
 
-#: src/msmtp.c:2261
+#: src/msmtp.c:2388
 #, c-format
 msgid ""
 "\n"
@@ -882,236 +889,236 @@ msgstr ""
 "\n"
 "Melden Sie Fehler an <%s>.\n"
 
-#: src/msmtp.c:2503 src/msmtp.c:2517
+#: src/msmtp.c:2633 src/msmtp.c:2647
 msgid "cannot use both --serverinfo and --rmqs"
 msgstr "--serverinfo und --rmqs kann nicht gleichzeitig benutzt werden"
 
-#: src/msmtp.c:2537 src/msmtp.c:2549
+#: src/msmtp.c:2667 src/msmtp.c:2679
 msgid "cannot use both --host and --account"
 msgstr "--host und --account kann nicht gleichzeitig benutzt werden"
 
-#: src/msmtp.c:2565 src/msmtp.c:2583 src/msmtp.c:2602 src/msmtp.c:2657
-#: src/msmtp.c:2689 src/msmtp.c:2707 src/msmtp.c:2770 src/msmtp.c:2815
-#: src/msmtp.c:2837 src/msmtp.c:2883 src/msmtp.c:2908 src/msmtp.c:2927
-#: src/msmtp.c:2980 src/msmtp.c:3025 src/msmtp.c:3052 src/msmtp.c:3070
-#: src/msmtp.c:3089 src/msmtp.c:3108 src/msmtp.c:3126 src/msmtp.c:3144
-#: src/msmtp.c:3221
+#: src/msmtp.c:2695 src/msmtp.c:2713 src/msmtp.c:2732 src/msmtp.c:2787
+#: src/msmtp.c:2819 src/msmtp.c:2837 src/msmtp.c:2900 src/msmtp.c:2945
+#: src/msmtp.c:2967 src/msmtp.c:3013 src/msmtp.c:3038 src/msmtp.c:3057
+#: src/msmtp.c:3110 src/msmtp.c:3155 src/msmtp.c:3182 src/msmtp.c:3200
+#: src/msmtp.c:3218 src/msmtp.c:3237 src/msmtp.c:3256 src/msmtp.c:3274
+#: src/msmtp.c:3292 src/msmtp.c:3369
 #, c-format
 msgid "invalid argument %s for %s"
 msgstr "ungültiges Argument %s für %s"
 
-#: src/msmtp.c:2612 src/msmtp.c:3184
+#: src/msmtp.c:2742 src/msmtp.c:3332
 msgid "cannot use both --from and --read-envelope-from"
 msgstr "--from und --read-envelope-from kann nicht gleichzeitig benutzt werden"
 
-#: src/msmtp.c:3199
+#: src/msmtp.c:3347
 #, c-format
 msgid "unsupported operation mode b%s"
 msgstr "Operationsmodus b%s nicht unterstützt"
 
-#: src/msmtp.c:3276 src/msmtp.c:3753 src/msmtp.c:4052
+#: src/msmtp.c:3424 src/msmtp.c:3904 src/msmtp.c:4204
 #, c-format
 msgid "cannot create temporary file: %s"
 msgstr "temporäre Datei kann nicht angelegt werden: %s"
 
-#: src/msmtp.c:3306 src/msmtp.c:3778 src/msmtp.c:4085
+#: src/msmtp.c:3454 src/msmtp.c:3930 src/msmtp.c:4243
 #, c-format
 msgid "cannot rewind temporary file: %s"
 msgstr "temporäre Datei kann nicht zurückgespult werden: %s"
 
-#: src/msmtp.c:3371
+#: src/msmtp.c:3520
 #, c-format
 msgid "ignoring system configuration file %s: %s\n"
 msgstr "Systemweite Konfigurationsdatei %s wird ignoriert: %s\n"
 
-#: src/msmtp.c:3386
+#: src/msmtp.c:3535
 #, c-format
 msgid "loaded system configuration file %s\n"
 msgstr "systemweite Konfigurationsdatei %s geladen\n"
 
-#: src/msmtp.c:3425
+#: src/msmtp.c:3574
 #, c-format
 msgid "ignoring user configuration file %s: %s\n"
 msgstr "Benutzerkonfigurationsdatei %s wird ignoriert: %s\n"
 
-#: src/msmtp.c:3440
+#: src/msmtp.c:3589
 #, c-format
 msgid "loaded user configuration file %s\n"
 msgstr "Benutzerkonfigurationsdatei %s geladen\n"
 
-#: src/msmtp.c:3497
+#: src/msmtp.c:3646
 #, c-format
 msgid "using account %s from %s\n"
 msgstr "Konto %s aus %s wird benutzt\n"
 
-#: src/msmtp.c:3503 src/msmtp.c:3505 src/msmtp.c:3508 src/msmtp.c:3542
-#: src/msmtp.c:3543 src/msmtp.c:3545 src/msmtp.c:3547 src/msmtp.c:3551
-#: src/msmtp.c:3553 src/msmtp.c:3572 src/msmtp.c:3574 src/msmtp.c:3576
-#: src/msmtp.c:3586 src/msmtp.c:3589 src/msmtp.c:3591 src/msmtp.c:3596
-#: src/msmtp.c:3599 src/msmtp.c:3611 src/msmtp.c:3613 src/msmtp.c:3615
-#: src/msmtp.c:3618 src/msmtp.c:3620 src/msmtp.c:3622
+#: src/msmtp.c:3650 src/msmtp.c:3653 src/msmtp.c:3655 src/msmtp.c:3658
+#: src/msmtp.c:3692 src/msmtp.c:3693 src/msmtp.c:3695 src/msmtp.c:3697
+#: src/msmtp.c:3701 src/msmtp.c:3703 src/msmtp.c:3722 src/msmtp.c:3724
+#: src/msmtp.c:3726 src/msmtp.c:3736 src/msmtp.c:3739 src/msmtp.c:3741
+#: src/msmtp.c:3746 src/msmtp.c:3749 src/msmtp.c:3761 src/msmtp.c:3763
+#: src/msmtp.c:3765 src/msmtp.c:3768 src/msmtp.c:3770 src/msmtp.c:3772
 msgid "(not set)"
 msgstr "(nicht festgelegt)"
 
-#: src/msmtp.c:3512
+#: src/msmtp.c:3662
 #, c-format
 msgid "off\n"
 msgstr "aus\n"
 
-#: src/msmtp.c:3518
+#: src/msmtp.c:3668
 #, c-format
 msgid "%d seconds\n"
 msgstr "%d Sekunden\n"
 
-#: src/msmtp.c:3522
+#: src/msmtp.c:3672
 #, c-format
 msgid "1 second\n"
 msgstr "1 Sekunde\n"
 
-#: src/msmtp.c:3531
+#: src/msmtp.c:3681
 #, c-format
 msgid "none\n"
 msgstr "keine\n"
 
-#: src/msmtp.c:3535
+#: src/msmtp.c:3685
 #, c-format
 msgid "choose\n"
 msgstr "wählen\n"
 
-#: src/msmtp.c:3548 src/msmtp.c:3549 src/msmtp.c:3578 src/msmtp.c:3594
-#: src/msmtp.c:3602 src/msmtp.c:3607 src/msmtp.c:3609
+#: src/msmtp.c:3698 src/msmtp.c:3699 src/msmtp.c:3728 src/msmtp.c:3744
+#: src/msmtp.c:3752 src/msmtp.c:3757 src/msmtp.c:3759
 msgid "on"
 msgstr "an"
 
-#: src/msmtp.c:3548 src/msmtp.c:3549 src/msmtp.c:3578 src/msmtp.c:3594
-#: src/msmtp.c:3602 src/msmtp.c:3605 src/msmtp.c:3607 src/msmtp.c:3609
+#: src/msmtp.c:3698 src/msmtp.c:3699 src/msmtp.c:3728 src/msmtp.c:3744
+#: src/msmtp.c:3752 src/msmtp.c:3755 src/msmtp.c:3757 src/msmtp.c:3759
 msgid "off"
 msgstr "aus"
 
-#: src/msmtp.c:3599
+#: src/msmtp.c:3749
 msgid "(read from mail)"
 msgstr "(aus Mail lesen)"
 
-#: src/msmtp.c:3601 src/msmtp.c:3604
+#: src/msmtp.c:3751 src/msmtp.c:3754
 msgid "auto"
 msgstr "automatisch"
 
-#: src/msmtp.c:3625
+#: src/msmtp.c:3775
 #, c-format
 msgid "reading recipients from the command line and the mail\n"
 msgstr "Empfängerliste aus Befehlszeile und Mail lesen\n"
 
-#: src/msmtp.c:3630
+#: src/msmtp.c:3780
 #, c-format
 msgid "reading recipients from the command line\n"
 msgstr "Empfängerliste aus Befehlszeile lesen\n"
 
-#: src/msmtp.c:3743
+#: src/msmtp.c:3894
 msgid "too many arguments"
 msgstr "zu viele Argumente"
 
-#: src/msmtp.c:3772
+#: src/msmtp.c:3924
 #, c-format
 msgid "envelope from address extracted from mail: %s\n"
 msgstr "Umschlagabsenderadresse aus Mail gelesen: %s\n"
 
-#: src/msmtp.c:3787
+#: src/msmtp.c:3939
 msgid "no recipients found"
 msgstr "keine Empfänger gefunden"
 
-#: src/msmtp.c:3817
+#: src/msmtp.c:3969
 #, c-format
 msgid "account chosen by envelope from address %s: %s\n"
 msgstr "Konto durch Umschlagabsenderadresse %s ausgewählt: %s\n"
 
-#: src/msmtp.c:3831
+#: src/msmtp.c:3983
 #, c-format
 msgid "falling back to default account\n"
 msgstr "Standardkonto wird benutzt\n"
 
-#: src/msmtp.c:3854
+#: src/msmtp.c:4006
 #, c-format
 msgid "using environment variables EMAIL and SMTPSERVER\n"
 msgstr "Umgebungsvariablen EMAIL und SMTPSERVER werden benutzt\n"
 
-#: src/msmtp.c:3862
+#: src/msmtp.c:4014
 #, c-format
 msgid "account %s not found in %s and %s"
 msgstr "Konto %s nicht in %s und %s gefunden"
 
-#: src/msmtp.c:3868 src/msmtp.c:3873
+#: src/msmtp.c:4020 src/msmtp.c:4025
 #, c-format
 msgid "account %s not found in %s"
 msgstr "Konto %s nicht in %s gefunden"
 
-#: src/msmtp.c:3878
+#: src/msmtp.c:4030
 #, c-format
 msgid "account %s not found: no configuration file available"
 msgstr "Konto %s nicht gefunden: Keine Konfigurationsdatei verfügbar"
 
-#: src/msmtp.c:3893
+#: src/msmtp.c:4045
 #, c-format
 msgid "using account specified on command line\n"
 msgstr "Konto von der Befehlszeile wird benutzt\n"
 
-#: src/msmtp.c:3959
+#: src/msmtp.c:4110
 #, c-format
 msgid "account %s from %s: %s"
 msgstr "Konto %s aus %s: %s"
 
-#: src/msmtp.c:4000
+#: src/msmtp.c:4151
 msgid "this platform does not support syslog logging"
 msgstr "diese Plattform unterstützt keine Syslog-Protokollierung"
 
-#: src/msmtp.c:4009
+#: src/msmtp.c:4160
 #, c-format
 msgid "support for authentication method %s is not compiled in"
 msgstr ""
 "Unterstützung für Authentifizierungsmethode %s ist nicht einkompiliert worden"
 
-#: src/msmtp.c:4017
+#: src/msmtp.c:4168
 #, c-format
 msgid "cannot initialize networking: %s"
 msgstr "Netzwerkprogrammbibliothek kann nicht initialisiert werden: %s"
 
-#: src/msmtp.c:4028
+#: src/msmtp.c:4179
 #, c-format
 msgid "cannot initialize TLS library: %s"
 msgstr "TLS-Programmbibliothek kann nicht initialisiert werden: %s"
 
-#: src/msmtp.c:4035
+#: src/msmtp.c:4186
 msgid "support for TLS is not compiled in"
 msgstr "Unterstützung für TLS ist nicht einkompiliert worden"
 
-#: src/msmtp.c:4114
+#: src/msmtp.c:4272
 #, c-format
 msgid "LMTP server message: %s"
 msgstr "Nachricht des LMTP-Servers: %s"
 
-#: src/msmtp.c:4125
+#: src/msmtp.c:4283
 #, c-format
 msgid "could not send mail to all recipients (account %s from %s)"
 msgstr "Mail konnte nicht an alle Empfänger geschickt werden (Konto %s aus %s)"
 
-#: src/msmtp.c:4131
+#: src/msmtp.c:4289
 msgid "could not send mail to all recipients"
 msgstr "Mail konnte nicht an alle Empfänger geschickt werden"
 
-#: src/msmtp.c:4146 src/msmtp.c:4201 src/msmtp.c:4222
+#: src/msmtp.c:4304 src/msmtp.c:4359 src/msmtp.c:4380
 #, c-format
 msgid "server message: %s"
 msgstr "Nachricht des Servers: %s"
 
-#: src/msmtp.c:4152
+#: src/msmtp.c:4310
 #, c-format
 msgid "could not send mail (account %s from %s)"
 msgstr "Mail konnte nicht verschickt werden (Konto %s aus %s)"
 
-#: src/msmtp.c:4157
+#: src/msmtp.c:4315
 msgid "could not send mail"
 msgstr "Mail konnte nicht verschickt werden"
 
-#: src/msmtp.c:4167
+#: src/msmtp.c:4325
 #, c-format
 msgid "delivery to one or more recipients failed"
 msgstr "Zustellung an einen oder mehrere Empfänger fehlgeschlagen"
@@ -1647,16 +1654,6 @@ msgstr "Verbindung zu %s, Port %d kann nicht hergestellt werden: %s"
 msgid "password for %s at %s: "
 msgstr ""
 
-#: src/password.c:252
-#, c-format
-msgid "cannot evaluate '%s': %s"
-msgstr "»%s« kann nicht ausgewertet werden: %s"
-
-#: src/password.c:262
-#, c-format
-msgid "cannot read output of '%s'"
-msgstr "Ausgabe von »%s« kann nicht gelesen werden"
-
 #: src/smtp.c:208
 #, c-format
 msgid "the server sent an empty reply"
@@ -1791,6 +1788,14 @@ msgstr "der Server kann die Anforderung nicht erfüllen"
 #, c-format
 msgid "invalid argument for Remote Message Queue Starting"
 msgstr "ungültiges Argument für »Remote Message Queue Starting«"
+
+#, c-format
+#~ msgid "cannot evaluate '%s': %s"
+#~ msgstr "»%s« kann nicht ausgewertet werden: %s"
+
+#, c-format
+#~ msgid "cannot read output of '%s'"
+#~ msgstr "Ausgabe von »%s« kann nicht gelesen werden"
 
 #~ msgid "Common Name"
 #~ msgstr "Allgemeiner Name"

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: msmtp 1.8.18\n"
 "Report-Msgid-Bugs-To: marlam@marlam.de\n"
-"POT-Creation-Date: 2022-03-23 20:22+0100\n"
+"POT-Creation-Date: 2022-07-27 18:42+0200\n"
 "PO-Revision-Date: 2021-10-24 12:15-0400\n"
 "Last-Translator: Keith Bowes <zooplah@gmail.com>\n"
 "Language-Team: Esperanto <translation-team-eo@lists.sourceforge.net>\n"
@@ -38,7 +38,7 @@ msgstr "linio %d: nevalida alinomo '%s'"
 msgid "line %d: duplicate alias '%s'"
 msgstr "linio %d: duobligita alinomo '%s'"
 
-#: src/aliases.c:178 src/conf.c:1072 src/stream.c:63
+#: src/aliases.c:178 src/conf.c:1193 src/stream.c:63
 #, c-format
 msgid "input error"
 msgstr "eniga eraro"
@@ -48,32 +48,32 @@ msgstr "eniga eraro"
 msgid "Too many redirects when expanding alias %s."
 msgstr "Tro da alidirektoj dum etendi alinomon %s."
 
-#: src/conf.c:808 src/conf.c:823
+#: src/conf.c:815 src/conf.c:830
 #, c-format
 msgid "host not set"
 msgstr "retnodo ne elektita"
 
-#: src/conf.c:813
+#: src/conf.c:820
 #, c-format
 msgid "port not set"
 msgstr "pordo ne elektita"
 
-#: src/conf.c:818
+#: src/conf.c:825
 #, c-format
 msgid "envelope-from address is missing"
 msgstr "envelope-from-retpoŝtadreso mankas"
 
-#: src/conf.c:828
+#: src/conf.c:835
 #, c-format
 msgid "tls_key_file requires tls_cert_file"
 msgstr "tls_cert_file estas postulata de tls_key_file"
 
-#: src/conf.c:833
+#: src/conf.c:840
 #, c-format
 msgid "tls_cert_file requires tls_key_file"
 msgstr "tls_key_file estas postulata de tls_cert_file"
 
-#: src/conf.c:841
+#: src/conf.c:848
 #, c-format
 msgid ""
 "tls requires either tls_trust_file (highly recommended) or tls_fingerprint "
@@ -82,73 +82,73 @@ msgstr ""
 "aŭ tls_trust_file (ege rekomendinda) aŭ tls_fingerprint aŭ malaktivigita "
 "tls_certcheck estas postulata de TLS"
 
-#: src/conf.c:847
+#: src/conf.c:854
 #, c-format
 msgid "tls_crl_file requires tls_trust_file"
 msgstr "tls_trush_file estas postulata de tls_crl_dosiero"
 
-#: src/conf.c:879 src/conf.c:886 src/conf.c:903 src/mtls-gnutls.c:328
+#: src/conf.c:886 src/conf.c:893 src/conf.c:910 src/mtls-gnutls.c:328
 #, c-format
 msgid "%s: %s"
 msgstr "%s: %s"
 
-#: src/conf.c:1094
-#, c-format
-msgid "line longer than %d characters"
-msgstr "linio pli longa ol %d signoj"
-
-#: src/conf.c:1145 src/conf.c:1270
+#: src/conf.c:1119 src/conf.c:1292
 #, c-format
 msgid "line %d: missing account name"
 msgstr "linio %d: mankas kontonomo"
 
-#: src/conf.c:1150
+#: src/conf.c:1124
 #, c-format
 msgid "line %d: account %s not (yet) defined"
 msgstr "linio %d: konto %s (ankoraŭ) ne estas difinita"
 
-#: src/conf.c:1242 src/conf.c:2060 src/conf.c:2077
+#: src/conf.c:1205
 #, c-format
-msgid "line %d: command %s does not take an argument"
-msgstr "linio %d: ne eblas doni al komando %s argumenton"
+msgid "line longer than %d characters"
+msgstr "linio pli longa ol %d signoj"
 
-#: src/conf.c:1278
-#, c-format
-msgid "line %d: an account name must not contain colons or commas"
-msgstr "linio %d: konto nomo devas ne havi dupunktojn aŭ komojn"
-
-#: src/conf.c:1288
-#, c-format
-msgid "line %d: account %s was already defined"
-msgstr "linio %d: konto %s jam estis difinita"
-
-#: src/conf.c:1313 src/conf.c:1332 src/conf.c:1359 src/conf.c:1388
-#: src/conf.c:1695 src/conf.c:1730
+#: src/conf.c:1222 src/conf.c:1335 src/conf.c:1354 src/conf.c:1381
+#: src/conf.c:1410 src/conf.c:1718 src/conf.c:1753
 #, c-format
 msgid "line %d: command %s needs an argument"
 msgstr "linio %d: komando %s postulas argumenton"
 
-#: src/conf.c:1343 src/conf.c:1375 src/conf.c:1406 src/conf.c:1440
-#: src/conf.c:1466 src/conf.c:1511 src/conf.c:1531 src/conf.c:1616
-#: src/conf.c:1637 src/conf.c:1656 src/conf.c:1717 src/conf.c:1748
-#: src/conf.c:1798 src/conf.c:1845 src/conf.c:1870 src/conf.c:1890
-#: src/conf.c:1910 src/conf.c:1930 src/conf.c:1977 src/conf.c:1998
-#: src/conf.c:2019 src/conf.c:2047
+#: src/conf.c:1264 src/conf.c:2103 src/conf.c:2120
+#, c-format
+msgid "line %d: command %s does not take an argument"
+msgstr "linio %d: ne eblas doni al komando %s argumenton"
+
+#: src/conf.c:1300
+#, c-format
+msgid "line %d: an account name must not contain colons or commas"
+msgstr "linio %d: konto nomo devas ne havi dupunktojn aŭ komojn"
+
+#: src/conf.c:1310
+#, c-format
+msgid "line %d: account %s was already defined"
+msgstr "linio %d: konto %s jam estis difinita"
+
+#: src/conf.c:1365 src/conf.c:1397 src/conf.c:1428 src/conf.c:1462
+#: src/conf.c:1488 src/conf.c:1534 src/conf.c:1554 src/conf.c:1639
+#: src/conf.c:1660 src/conf.c:1679 src/conf.c:1740 src/conf.c:1771
+#: src/conf.c:1821 src/conf.c:1868 src/conf.c:1893 src/conf.c:1913
+#: src/conf.c:1933 src/conf.c:1953 src/conf.c:1973 src/conf.c:2020
+#: src/conf.c:2041 src/conf.c:2062 src/conf.c:2090
 #, c-format
 msgid "line %d: invalid argument %s for command %s"
 msgstr "linio %d: nevalida argumento %s por komando %s"
 
-#: src/conf.c:2093
+#: src/conf.c:2136
 #, c-format
 msgid "line %d: unknown command %s"
 msgstr "linio %d: nekonato komando %s"
 
-#: src/conf.c:2145
+#: src/conf.c:2190
 #, c-format
 msgid "contains secrets and therefore must be owned by you"
 msgstr "enhavas sekretojn kaj tial devas esti estrata de vi"
 
-#: src/conf.c:2151
+#: src/conf.c:2196
 #, c-format
 msgid ""
 "contains secrets and therefore must have no more than user read/write "
@@ -159,101 +159,101 @@ msgstr ""
 
 #. TRANSLATORS: msmtp shares a lot of code and translatable strings with
 #. mpop <https://marlam.de/mpop>.
-#: src/msmtp.c:88
+#: src/msmtp.c:90
 #, c-format
 msgid "%s: FATAL: %s\n"
 msgstr "%s: FATALA: %s\n"
 
-#: src/msmtp.c:228 src/msmtp.c:406 src/msmtp.c:1401
+#: src/msmtp.c:230 src/msmtp.c:408 src/msmtp.c:1522
 #, c-format
 msgid "the server does not support TLS via the STARTTLS command"
 msgstr "la servilo ne regas TLS-on per la komando STLS"
 
-#: src/msmtp.c:270
+#: src/msmtp.c:272
 #, c-format
 msgid "the server does not support Remote Message Queue Starting"
 msgstr "la servilo ne regas startigon de fora mesaĝatendovico (RMQS)"
 
-#: src/msmtp.c:282 src/msmtp.c:1459
+#: src/msmtp.c:284 src/msmtp.c:1580
 #, c-format
 msgid "the server does not support authentication"
 msgstr "la servilo ne regas aŭtentigon"
 
-#: src/msmtp.c:441
+#: src/msmtp.c:443
 #, c-format
 msgid "%s server at %s (%s [%s]), port %d:\n"
 msgstr "%s-servilo ĉe %s (%s [%s]), pordo %d\n"
 
-#: src/msmtp.c:447
+#: src/msmtp.c:450
 #, c-format
 msgid "%s server at %s (%s), port %d:\n"
 msgstr "%s-servilo ĉe %s (%s), pordo %d:\n"
 
-#: src/msmtp.c:453
+#: src/msmtp.c:457
 #, c-format
 msgid "%s server at %s ([%s]), port %d:\n"
 msgstr "%s-servilo ĉe %s ([%s]), pordo %d:\n"
 
-#: src/msmtp.c:459
+#: src/msmtp.c:464
 #, c-format
 msgid "%s server at %s, port %d:\n"
 msgstr "%s-servilo ĉe %s, pordo %d:\n"
 
-#: src/msmtp.c:479
+#: src/msmtp.c:485
 #, c-format
 msgid "No special capabilities.\n"
 msgstr "Neniuj specialaj kapabloj,\n"
 
-#: src/msmtp.c:483
+#: src/msmtp.c:489
 #, c-format
 msgid "Capabilities:\n"
 msgstr "Kapabloj:\n"
 
-#: src/msmtp.c:487
+#: src/msmtp.c:493
 msgid "Maximum message size is "
 msgstr "Maksimuma mesaĝgrando estas "
 
-#: src/msmtp.c:490
+#: src/msmtp.c:496
 #, c-format
 msgid "unlimited\n"
 msgstr "nelimigita\n"
 
-#: src/msmtp.c:494
+#: src/msmtp.c:500
 #, c-format
 msgid "%ld bytes"
 msgstr "%ld bajtoj"
 
-#: src/msmtp.c:497
+#: src/msmtp.c:503
 #, c-format
 msgid " = %.2f MiB"
 msgstr " = %.2f MiB"
 
-#: src/msmtp.c:502
+#: src/msmtp.c:508
 #, c-format
 msgid " = %.2f KiB"
 msgstr " = %.2f KiB"
 
-#: src/msmtp.c:509
+#: src/msmtp.c:515
 msgid "Support for command grouping for faster transmission"
 msgstr "Rego por grupigo de komandoj por pli rapida elsendado"
 
-#: src/msmtp.c:514
+#: src/msmtp.c:520
 msgid "Support for RMQS (Remote Message Queue Starting)"
 msgstr "Rego de RMQS (startigo de fora mesaĝatendovico)"
 
-#: src/msmtp.c:519
+#: src/msmtp.c:525
 msgid "Support for Delivery Status Notifications"
 msgstr "Rego de DSN (sciigoj pri stato de liverado)"
 
-#: src/msmtp.c:529
+#: src/msmtp.c:535
 msgid "Support for TLS encryption via the STARTTLS command"
 msgstr "Rego de TLS-ĉifrado per la komando STARTTLS"
 
-#: src/msmtp.c:535
+#: src/msmtp.c:541
 msgid "Supported authentication methods:"
 msgstr "Regataj aŭtentigaj metodoj:"
 
-#: src/msmtp.c:588
+#: src/msmtp.c:594
 #, c-format
 msgid ""
 "This server might advertise more or other capabilities when TLS is active.\n"
@@ -261,112 +261,112 @@ msgstr ""
 "La servilo eble pretendus pliajn aŭ aliajn kapablojn\n"
 "    kiam TLS estas aktiva.\n"
 
-#: src/msmtp.c:1153 src/msmtp.c:3299
+#: src/msmtp.c:1274 src/msmtp.c:3447
 #, c-format
 msgid "cannot write mail headers to temporary file: output error"
 msgstr "ne eblas skribi retpoŝtajn ĉapojn al provizora dosiero: eliga eraro"
 
-#: src/msmtp.c:1261
+#: src/msmtp.c:1382
 #, c-format
 msgid "input error while reading the mail"
 msgstr "eniga eraro dum legi la retpoŝtaĵon"
 
-#: src/msmtp.c:1448
+#: src/msmtp.c:1569
 #, c-format
 msgid "the server does not support DSN"
 msgstr "la servilo ne regas DSN-on"
 
-#: src/msmtp.c:1597 src/msmtp.c:1616 src/msmtp.c:1668
+#: src/msmtp.c:1718 src/msmtp.c:1737 src/msmtp.c:1789
 #, c-format
 msgid "automatic configuration based on SRV records failed: %s"
 msgstr "aŭtomata agordado bazita sur SRV-rikordoj malsukcesis: %s"
 
-#: src/msmtp.c:1598
+#: src/msmtp.c:1719
 msgid "invalid mail address"
 msgstr "nevalida retpoŝtadreso"
 
-#: src/msmtp.c:1614
+#: src/msmtp.c:1735
 #, c-format
 msgid "no SRV records for %s or %s"
 msgstr "neniuj SRV-rikordoj por %s aŭ %s"
 
-#: src/msmtp.c:1631
+#: src/msmtp.c:1752
 #, c-format
 msgid "copy this to your configuration file %s"
 msgstr "kopiu la jenan en vian agordo-dosieron %s"
 
-#: src/msmtp.c:1635
+#: src/msmtp.c:1756
 msgid "warning: the host does not match the mail domain; please check"
 msgstr ""
 "averto: la retnodo ne kongruas kun la retpoŝta domajno; bonvolu kontroli"
 
-#: src/msmtp.c:1638 src/msmtp.c:1642
+#: src/msmtp.c:1759 src/msmtp.c:1763
 msgid "add your password to the key ring:"
 msgstr "aldoni vian pasvorton al la ŝlosilaro"
 
-#: src/msmtp.c:1645
+#: src/msmtp.c:1766
 msgid "encrypt your password:"
 msgstr "ĉifri vian pasvorton:"
 
-#: src/msmtp.c:1669
+#: src/msmtp.c:1790
 msgid "this system lacks libresolv"
 msgstr "la sistemo malhavas la bibliotekon libresolv"
 
-#: src/msmtp.c:1896
+#: src/msmtp.c:2022
 #, c-format
 msgid "invalid logfile_time_format"
 msgstr "nevalida logfile_time_format"
 
-#: src/msmtp.c:1909
+#: src/msmtp.c:2035
 #, c-format
 msgid "cannot open: %s"
 msgstr "ne eblas malfermi: %s"
 
-#: src/msmtp.c:1917
+#: src/msmtp.c:2043
 #, c-format
 msgid "cannot lock (tried for %d seconds): %s"
 msgstr "ne eblas fiksi (provis dum %d sekundoj): %s"
 
-#: src/msmtp.c:1922
+#: src/msmtp.c:2048
 #, c-format
 msgid "cannot lock: %s"
 msgstr "ne eblas fiksi: %s"
 
-#: src/msmtp.c:1931
+#: src/msmtp.c:2057
 msgid "output error"
 msgstr "eliga eraro"
 
-#: src/msmtp.c:1948
+#: src/msmtp.c:2074
 #, c-format
 msgid "cannot log to %s: %s"
 msgstr "ne eblas protokoli al %s: %s"
 
-#: src/msmtp.c:1952
+#: src/msmtp.c:2078
 #, c-format
 msgid "log info was: %s"
 msgstr "protokola informo estis: %s"
 
-#: src/msmtp.c:2061
+#: src/msmtp.c:2187
 #, c-format
 msgid "%s version %s\n"
 msgstr "%s eldono %s\n"
 
-#: src/msmtp.c:2062
+#: src/msmtp.c:2188
 #, c-format
 msgid "Platform: %s\n"
 msgstr "Platformo: %s\n"
 
-#: src/msmtp.c:2064
+#: src/msmtp.c:2190
 #, c-format
 msgid "TLS/SSL library: %s\n"
 msgstr "TLS/SSL-biblioteko: %s\n"
 
-#: src/msmtp.c:2072 src/msmtp.c:2150
+#: src/msmtp.c:2198 src/msmtp.c:2276
 #, c-format
 msgid "none"
 msgstr "nenio"
 
-#: src/msmtp.c:2076
+#: src/msmtp.c:2202
 #, c-format
 msgid ""
 "Authentication library: %s\n"
@@ -375,65 +375,65 @@ msgstr ""
 "Aŭtentiga biblioteko: %s\n"
 "Regataj aŭtentaj metodoj:\n"
 
-#: src/msmtp.c:2079
+#: src/msmtp.c:2205
 msgid "GNU SASL; oauthbearer and xoauth2: built-in"
 msgstr "GNU SASL; oauthbearer kaj xoauth2: apriora"
 
-#: src/msmtp.c:2081
+#: src/msmtp.c:2207
 msgid "built-in"
 msgstr "apriora"
 
-#: src/msmtp.c:2130
+#: src/msmtp.c:2256
 #, c-format
 msgid "IDN support: "
 msgstr "IDN-rego: "
 
-#: src/msmtp.c:2134 src/msmtp.c:2142
+#: src/msmtp.c:2260 src/msmtp.c:2268
 #, c-format
 msgid "enabled"
 msgstr "aktiva"
 
-#: src/msmtp.c:2136 src/msmtp.c:2145
+#: src/msmtp.c:2262 src/msmtp.c:2271
 #, c-format
 msgid "disabled"
 msgstr "malaktiva"
 
-#: src/msmtp.c:2140
+#: src/msmtp.c:2266
 #, c-format
 msgid "NLS: "
 msgstr "NLS: "
 
-#: src/msmtp.c:2143
+#: src/msmtp.c:2269
 #, c-format
 msgid ", LOCALEDIR is %s"
 msgstr ", LOCALEDIR estas %s"
 
-#: src/msmtp.c:2148
+#: src/msmtp.c:2274
 #, c-format
 msgid "Keyring support: "
 msgstr "Regado de ŝlosilaro: "
 
-#: src/msmtp.c:2153
+#: src/msmtp.c:2279
 #, c-format
 msgid "Gnome "
 msgstr "Gnome "
 
-#: src/msmtp.c:2156
+#: src/msmtp.c:2282
 #, c-format
 msgid "MacOS "
 msgstr "MacOS "
 
-#: src/msmtp.c:2162
+#: src/msmtp.c:2288
 #, c-format
 msgid "System configuration file name: %s\n"
 msgstr "Sistema gordo-dosiernomo: %s\n"
 
-#: src/msmtp.c:2166
+#: src/msmtp.c:2292
 #, c-format
 msgid "User configuration file name: %s\n"
 msgstr "agordo-dosiernomo de uzanto: %s\n"
 
-#: src/msmtp.c:2169
+#: src/msmtp.c:2295
 #, c-format
 msgid ""
 "Copyright (C) %d Martin Lambers and others.\n"
@@ -449,7 +449,7 @@ msgstr ""
 "html>.\n"
 "Ekzistas NENIU GARANTIO, escepte kiom postulata de la leĝaro.\n"
 
-#: src/msmtp.c:2186
+#: src/msmtp.c:2312
 #, c-format
 msgid ""
 "Usage:\n"
@@ -458,7 +458,7 @@ msgstr ""
 "Uzado:\n"
 "\n"
 
-#: src/msmtp.c:2187
+#: src/msmtp.c:2313
 #, c-format
 msgid ""
 "Sendmail mode (default):\n"
@@ -473,7 +473,7 @@ msgstr ""
 "  Legi retpoŝtaĵon el la ĉefenigujo kaj elsendi ĝin al SMTP- aŭ LMTP- "
 "servilo.\n"
 
-#: src/msmtp.c:2192
+#: src/msmtp.c:2318
 #, c-format
 msgid ""
 "Configuration mode:\n"
@@ -484,7 +484,7 @@ msgstr ""
 "  %s --configure=retpoŝtadreso\n"
 "  Generi kaj eligi agordon por la retpoŝtadreson.\n"
 
-#: src/msmtp.c:2195
+#: src/msmtp.c:2321
 #, c-format
 msgid ""
 "Server information mode:\n"
@@ -495,7 +495,7 @@ msgstr ""
 "  %s [elekteblo...] --serverinfo\n"
 "  Eligi informojn pri servilo.\n"
 
-#: src/msmtp.c:2198
+#: src/msmtp.c:2324
 #, c-format
 msgid ""
 "Remote Message Queue Starting mode:\n"
@@ -508,49 +508,49 @@ msgstr ""
 "  Peti al servilo startigi foran mesaĝatendovicon (RMQS-peto).\n"
 "\n"
 
-#: src/msmtp.c:2202
+#: src/msmtp.c:2328
 #, c-format
 msgid "General options:\n"
 msgstr "Ĝeneralaj elektebloj:\n"
 
-#: src/msmtp.c:2203
+#: src/msmtp.c:2329
 #, c-format
 msgid "  --version                    print version\n"
 msgstr "  --version                    eligi eldonon\n"
 
-#: src/msmtp.c:2204
+#: src/msmtp.c:2330
 #, c-format
 msgid "  --help                       print help\n"
 msgstr "  --help                       eligi helpon\n"
 
-#: src/msmtp.c:2205
+#: src/msmtp.c:2331
 #, c-format
 msgid "  -P, --pretend                print configuration info and exit\n"
 msgstr "  -P, --pretend                eligi agordajn informojn kaj fini\n"
 
-#: src/msmtp.c:2206
+#: src/msmtp.c:2332
 #, c-format
 msgid "  -d, --debug                  print debugging information\n"
 msgstr "  -d, --debug                  eligi senerarigajn informojn\n"
 
-#: src/msmtp.c:2207
+#: src/msmtp.c:2333
 #, c-format
 msgid "Changing the mode of operation:\n"
 msgstr "Por ŝanĝi la operacireĝimo:\n"
 
-#: src/msmtp.c:2208
+#: src/msmtp.c:2334
 #, c-format
 msgid ""
 "  --configure=mailaddress      generate and print configuration for address\n"
 msgstr ""
 "  --configure=retpoŝtadreson    generi kaj eligi agordon por retpoŝtadreso\n"
 
-#: src/msmtp.c:2209
+#: src/msmtp.c:2335
 #, c-format
 msgid "  -S, --serverinfo             print information about the server\n"
 msgstr "  -S, --serverinfo             eligi informojn pri la servilo\n"
 
-#: src/msmtp.c:2210
+#: src/msmtp.c:2336
 #, c-format
 msgid ""
 "  --rmqs=host|@domain|#queue   send a Remote Message Queue Starting request\n"
@@ -559,17 +559,17 @@ msgstr ""
 "                                send a Remote Message Queue Starting "
 "request\n"
 
-#: src/msmtp.c:2211
+#: src/msmtp.c:2337
 #, c-format
 msgid "Configuration options:\n"
 msgstr "Agordaj elektebloj:\n"
 
-#: src/msmtp.c:2212
+#: src/msmtp.c:2338
 #, c-format
 msgid "  -C, --file=filename          set configuration file\n"
 msgstr "  -C, --file=filename          elekti agordo-dosieron\n"
 
-#: src/msmtp.c:2213
+#: src/msmtp.c:2339
 #, c-format
 msgid ""
 "  -a, --account=id             use the given account instead of the account\n"
@@ -582,7 +582,7 @@ msgstr ""
 "agordon \n"
 "                               per komandliniaj elektebloj\n"
 
-#: src/msmtp.c:2216
+#: src/msmtp.c:2342
 #, c-format
 msgid ""
 "  --host=hostname              set the server, use only command-line "
@@ -593,12 +593,12 @@ msgstr ""
 "agordaĵojn\n"
 "                               ne uzi la agordo-dosieron\n"
 
-#: src/msmtp.c:2218
+#: src/msmtp.c:2344
 #, c-format
 msgid "  --port=number                set port number\n"
 msgstr "  --port=numero                elekti pordo-numeron\n"
 
-#: src/msmtp.c:2219
+#: src/msmtp.c:2345
 #, c-format
 msgid ""
 "  --source-ip=[IP]             set/unset source ip address to bind the "
@@ -607,36 +607,36 @@ msgstr ""
 "  --source-ip=[IP]             elekti/malelekti la adreson al kiu bindi la  "
 "ŝtopilingon\n"
 
-#: src/msmtp.c:2220
+#: src/msmtp.c:2346
 #, c-format
 msgid "  --proxy-host=[IP|hostname]   set/unset proxy\n"
 msgstr "  --proxy-host=[IP|retnodnomo] elekti/malelekti prokurilon\n"
 
-#: src/msmtp.c:2221
+#: src/msmtp.c:2347
 #, c-format
 msgid "  --proxy-port=[number]        set/unset proxy port\n"
 msgstr "  --proxy-port=[numero]        elekti/malelekti prokurilan pordon\n"
 
-#: src/msmtp.c:2222
+#: src/msmtp.c:2348
 #, c-format
 msgid "  --socket=[socketname]        set/unset local socket to connect to\n"
 msgstr ""
 "  --socket=[nomo]              elekti/malelekti la lokan ŝtopilingon al kiu "
 "konektiĝi\n"
 
-#: src/msmtp.c:2223
+#: src/msmtp.c:2349
 #, c-format
 msgid "  --timeout=(off|seconds)      set/unset network timeout in seconds\n"
 msgstr ""
 "--timeout=(off|sekundoj)       elekti la retan eksvalidiĝon laŭ sekundoj, aŭ "
 "malŝalti ĝin (per ŝlosilvorto off)\n"
 
-#: src/msmtp.c:2224
+#: src/msmtp.c:2350
 #, c-format
 msgid "  --protocol=(smtp|lmtp)       use the given sub protocol\n"
 msgstr "  --protocol=(smtp|lmtp)       uzi la donatan subprotokolon\n"
 
-#: src/msmtp.c:2225
+#: src/msmtp.c:2351
 #, c-format
 msgid ""
 "  --domain=string              set the argument of EHLO or LHLO command\n"
@@ -644,7 +644,7 @@ msgstr ""
 "  --domain=ĉeno                 elekti la argumenton de la komando EHLO aŭ "
 "LHLO\n"
 
-#: src/msmtp.c:2226
+#: src/msmtp.c:2352
 #, c-format
 msgid ""
 "  --auth[=(on|off|method)]     enable/disable authentication and optionally\n"
@@ -654,40 +654,40 @@ msgstr ""
 "ŝlosilvortoj on/off)\n"
 "                                aŭ elekti la metodon\n"
 
-#: src/msmtp.c:2228
+#: src/msmtp.c:2354
 #, c-format
 msgid "  --user=[username]            set/unset user name for authentication\n"
 msgstr ""
 "  --user=[salutnomo]          elekti la salutnomon uzeblan por aŭtentigi\n"
 
-#: src/msmtp.c:2229
+#: src/msmtp.c:2355
 #, c-format
 msgid "  --passwordeval=[eval]        evaluate password for authentication\n"
 msgstr "  --passwordeval=[eval]        taksi pasvorton por aŭtentigi\n"
 
-#: src/msmtp.c:2230
+#: src/msmtp.c:2356
 #, c-format
 msgid "  --tls[=(on|off)]             enable/disable TLS encryption\n"
 msgstr "  --tls[=(on|off)]             aktivigi/malaktivigi TLS-ĉifradon\n"
 
-#: src/msmtp.c:2231
+#: src/msmtp.c:2357
 #, c-format
 msgid "  --tls-starttls[=(on|off)]    enable/disable STARTTLS for TLS\n"
 msgstr "  --tls-starttls[=(on|off)]    aktivigi/malaktivigi STARTTLS por TLS\n"
 
-#: src/msmtp.c:2232
+#: src/msmtp.c:2358
 #, c-format
 msgid "  --tls-trust-file=[file]      set/unset trust file for TLS\n"
 msgstr ""
 "  --tls-trust-file=[dosiero]      elekti/malelekti fido-dosieron por TLS\n"
 
-#: src/msmtp.c:2233
+#: src/msmtp.c:2359
 #, c-format
 msgid "  --tls-crl-file=[file]        set/unset revocation file for TLS\n"
 msgstr ""
 "  --tls-crl-file=[dosiero]     elekti/malelekti revokodosieron por TLS\n"
 
-#: src/msmtp.c:2234
+#: src/msmtp.c:2360
 #, c-format
 msgid ""
 "  --tls-fingerprint=[f]        set/unset trusted certificate fingerprint for "
@@ -696,7 +696,7 @@ msgstr ""
 "  --tls-fingerprint=[f]        elekti/malelekti atestilan fingropremaĵon  "
 "por TLS\n"
 
-#: src/msmtp.c:2235
+#: src/msmtp.c:2361
 #, c-format
 msgid ""
 "  --tls-certcheck[=(on|off)]   enable/disable server certificate checks for "
@@ -705,26 +705,26 @@ msgstr ""
 "  --tls-certcheck[=(on|off)]   aktivigi/malaktivigi kontroladon de servilaj "
 "atestiloj por TLS\n"
 
-#: src/msmtp.c:2236
+#: src/msmtp.c:2362
 #, c-format
 msgid "  --tls-key-file=[file]        set/unset private key file for TLS\n"
 msgstr ""
 "  --tls-key-file=[file]        elekti/malelekti dosieron privata ŝlosilo por "
 "TLS \n"
 
-#: src/msmtp.c:2237
+#: src/msmtp.c:2363
 #, c-format
 msgid "  --tls-cert-file=[file]       set/unset private cert file for TLS\n"
 msgstr ""
 "  --tls-cert-file=[file]       elekti/malelekti dosieron de privata atestilo "
 "por TLS\n"
 
-#: src/msmtp.c:2238
+#: src/msmtp.c:2364
 #, c-format
 msgid "  --tls-priorities=[prios]     set/unset TLS priorities.\n"
 msgstr "  --tls-priorities=[prio]      elekti/malelekti TLS-prioritatojn.\n"
 
-#: src/msmtp.c:2239
+#: src/msmtp.c:2365
 #, c-format
 msgid ""
 "  --tls-host-override=[host]   set/unset override for TLS host "
@@ -733,19 +733,19 @@ msgstr ""
 "  --tls-host-override=[retnodo] elekti/malelekti superregadon por aŭtentigo "
 "de TLS-retnodo.\n"
 
-#: src/msmtp.c:2240
+#: src/msmtp.c:2366
 #, c-format
 msgid "  --tls-min-dh-prime-bits=[b]  set/unset minimum bit size of DH prime\n"
 msgstr ""
 "  --tls-min-dh-prime-bits=[b]  elekti/malelekti minimuman bitgrandon de DH-"
 "primo\n"
 
-#: src/msmtp.c:2241
+#: src/msmtp.c:2367
 #, c-format
 msgid "Options specific to sendmail mode:\n"
 msgstr "Elektebloj specifaj por sendmail-reĝimo:\n"
 
-#: src/msmtp.c:2242
+#: src/msmtp.c:2368
 #, c-format
 msgid ""
 "  --auto-from[=(on|off)]       enable/disable automatic envelope-from "
@@ -754,12 +754,12 @@ msgstr ""
 "  --auto-from[=(on|off)]       aktivigi/malaktivig aŭtomatan uzon de "
 "envelope-from\n"
 
-#: src/msmtp.c:2243
+#: src/msmtp.c:2369
 #, c-format
 msgid "  -f, --from=address           set envelope from address\n"
 msgstr "  -f, --from=address           elekti koverton de retpoŝtadreso\n"
 
-#: src/msmtp.c:2244
+#: src/msmtp.c:2370
 #, c-format
 msgid ""
 "  --maildomain=[domain]        set the domain for automatic envelope from\n"
@@ -768,29 +768,29 @@ msgstr ""
 "  --maildomain=[domajno]       elekti la domajnon por aŭtomata envelope-"
 "from\n"
 
-#: src/msmtp.c:2246
+#: src/msmtp.c:2372
 #, c-format
 msgid "  -N, --dsn-notify=(off|cond)  set/unset DSN conditions\n"
 msgstr "  -N, --dsn-notify=(off|kond)  elekti/malekti DSN-kondiĉojn\n"
 
-#: src/msmtp.c:2247
+#: src/msmtp.c:2373
 #, c-format
 msgid "  -R, --dsn-return=(off|ret)   set/unset DSN amount\n"
 msgstr "  -R, --dsn-return=(off|rev)   elekti/malelekti DNS-kiomon\n"
 
-#: src/msmtp.c:2248
+#: src/msmtp.c:2374
 #, c-format
 msgid "  -X, --logfile=[file]         set/unset log file\n"
 msgstr "  -X, --logfile=[dosiero]      elekti/malelekti protokolon\n"
 
-#: src/msmtp.c:2249
+#: src/msmtp.c:2375
 #, c-format
 msgid ""
 "  --logfile-time-format=[fmt]  set/unset log file time format for "
 "strftime()\n"
 msgstr "  --logfile-time-format=[fmt]  tempoformato por protokoloj\n"
 
-#: src/msmtp.c:2250
+#: src/msmtp.c:2376
 #, c-format
 msgid ""
 "  --syslog[=(on|off|facility)] enable/disable/configure syslog logging\n"
@@ -798,14 +798,14 @@ msgstr ""
 "  --syslog[=(on|off|fako)]     aktivigi/malaktivigi/agordi syslog-"
 "protokoladon\n"
 
-#: src/msmtp.c:2251
+#: src/msmtp.c:2377
 #, c-format
 msgid ""
 "  -t, --read-recipients        read additional recipients from the mail\n"
 msgstr ""
 "  -t, --read-recipients        legi aldonajn ricevontojn de la retpoŝtaĵo\n"
 
-#: src/msmtp.c:2252
+#: src/msmtp.c:2378
 #, c-format
 msgid ""
 "  --read-envelope-from         read envelope from address from the mail\n"
@@ -813,22 +813,28 @@ msgstr ""
 "  --read-envelope-from         legi la envelope-from-adreson de la "
 "retpoŝtaĵo\n"
 
-#: src/msmtp.c:2253
+#: src/msmtp.c:2379
 #, c-format
 msgid "  --aliases=[file]             set/unset aliases file\n"
 msgstr "  --aliases=[file]             elekti/malelekti alinomo-dosieron\n"
 
-#: src/msmtp.c:2254
+#: src/msmtp.c:2380
 #, c-format
 msgid "  --set-from-header[=(auto|on|off)] set From header handling\n"
 msgstr "  --set-from-header[=(auto|on|off)] elekti traktadon de From-ĉapo\n"
 
-#: src/msmtp.c:2255
+#: src/msmtp.c:2381
 #, c-format
 msgid "  --set-date-header[=(auto|off)] set Date header handling\n"
 msgstr "  --set-date-header[=(auto|off)] elekti traktadon de Date-ĉapon\n"
 
-#: src/msmtp.c:2256
+#: src/msmtp.c:2382
+#, fuzzy, c-format
+#| msgid "  --set-date-header[=(auto|off)] set Date header handling\n"
+msgid "  --set-msgid-header[=(auto|off)] set Message-ID header handling\n"
+msgstr "  --set-date-header[=(auto|off)] elekti traktadon de Date-ĉapon\n"
+
+#: src/msmtp.c:2383
 #, c-format
 msgid ""
 "  --remove-bcc-headers[=(on|off)] enable/disable removal of Bcc headers\n"
@@ -836,7 +842,7 @@ msgstr ""
 "  --remove-bcc-headers[=(on|off)] aktivigi/malaktivigi forigon de Bcc-"
 "ĉapojn\n"
 
-#: src/msmtp.c:2257
+#: src/msmtp.c:2384
 #, c-format
 msgid ""
 "  --undisclosed-recipients[=(on|off)] enable/disable replacement of To/Cc/"
@@ -847,12 +853,12 @@ msgstr ""
 "To/Cc/Bcc\n"
 "                               per To: undisclosed-recipients:;\n"
 
-#: src/msmtp.c:2259
+#: src/msmtp.c:2386
 #, c-format
 msgid "  --                           end of options\n"
 msgstr "  --                           fino de elektebloj\n"
 
-#: src/msmtp.c:2260
+#: src/msmtp.c:2387
 #, c-format
 msgid ""
 "Accepted but ignored: -A, -B, -bm, -F, -G, -h, -i, -L, -m, -n, -O, -o, -v\n"
@@ -860,7 +866,7 @@ msgstr ""
 "Rekonataj sed ignorataj: -A, -B, -bm, -F, -G, -h, -i, -L, -m, -n, -O, -o, -"
 "v\n"
 
-#: src/msmtp.c:2261
+#: src/msmtp.c:2388
 #, c-format
 msgid ""
 "\n"
@@ -869,235 +875,235 @@ msgstr ""
 "\n"
 "Raportu programerarojn al <%s>.\n"
 
-#: src/msmtp.c:2503 src/msmtp.c:2517
+#: src/msmtp.c:2633 src/msmtp.c:2647
 msgid "cannot use both --serverinfo and --rmqs"
 msgstr "ne povas uzi kaj --serverinfo kaj --rmqs"
 
-#: src/msmtp.c:2537 src/msmtp.c:2549
+#: src/msmtp.c:2667 src/msmtp.c:2679
 msgid "cannot use both --host and --account"
 msgstr "ne povas uzi kaj --host kaj --accounts"
 
-#: src/msmtp.c:2565 src/msmtp.c:2583 src/msmtp.c:2602 src/msmtp.c:2657
-#: src/msmtp.c:2689 src/msmtp.c:2707 src/msmtp.c:2770 src/msmtp.c:2815
-#: src/msmtp.c:2837 src/msmtp.c:2883 src/msmtp.c:2908 src/msmtp.c:2927
-#: src/msmtp.c:2980 src/msmtp.c:3025 src/msmtp.c:3052 src/msmtp.c:3070
-#: src/msmtp.c:3089 src/msmtp.c:3108 src/msmtp.c:3126 src/msmtp.c:3144
-#: src/msmtp.c:3221
+#: src/msmtp.c:2695 src/msmtp.c:2713 src/msmtp.c:2732 src/msmtp.c:2787
+#: src/msmtp.c:2819 src/msmtp.c:2837 src/msmtp.c:2900 src/msmtp.c:2945
+#: src/msmtp.c:2967 src/msmtp.c:3013 src/msmtp.c:3038 src/msmtp.c:3057
+#: src/msmtp.c:3110 src/msmtp.c:3155 src/msmtp.c:3182 src/msmtp.c:3200
+#: src/msmtp.c:3218 src/msmtp.c:3237 src/msmtp.c:3256 src/msmtp.c:3274
+#: src/msmtp.c:3292 src/msmtp.c:3369
 #, c-format
 msgid "invalid argument %s for %s"
 msgstr "nevalida argumento %s por %s"
 
-#: src/msmtp.c:2612 src/msmtp.c:3184
+#: src/msmtp.c:2742 src/msmtp.c:3332
 msgid "cannot use both --from and --read-envelope-from"
 msgstr "ne povas uzi kaj --host kaj --read-envelope-from"
 
-#: src/msmtp.c:3199
+#: src/msmtp.c:3347
 #, c-format
 msgid "unsupported operation mode b%s"
 msgstr "neregata operacia reĝimo b%s"
 
-#: src/msmtp.c:3276 src/msmtp.c:3753 src/msmtp.c:4052
+#: src/msmtp.c:3424 src/msmtp.c:3904 src/msmtp.c:4204
 #, c-format
 msgid "cannot create temporary file: %s"
 msgstr "ne eblas krei provizoran dosieron: %s"
 
-#: src/msmtp.c:3306 src/msmtp.c:3778 src/msmtp.c:4085
+#: src/msmtp.c:3454 src/msmtp.c:3930 src/msmtp.c:4243
 #, c-format
 msgid "cannot rewind temporary file: %s"
 msgstr "ne eblas malantaŭenigi provizoran dosieron: %s"
 
-#: src/msmtp.c:3371
+#: src/msmtp.c:3520
 #, c-format
 msgid "ignoring system configuration file %s: %s\n"
 msgstr "ignoras sisteman agordo-dosieron %s: %s\n"
 
-#: src/msmtp.c:3386
+#: src/msmtp.c:3535
 #, c-format
 msgid "loaded system configuration file %s\n"
 msgstr "ŝargis sisteman agordo-dosieron %s\n"
 
-#: src/msmtp.c:3425
+#: src/msmtp.c:3574
 #, c-format
 msgid "ignoring user configuration file %s: %s\n"
 msgstr "ignoras agordo-dosieron %s de uzanto: %s\n"
 
-#: src/msmtp.c:3440
+#: src/msmtp.c:3589
 #, c-format
 msgid "loaded user configuration file %s\n"
 msgstr "ŝargis agordo dosieron %s du uzanto\n"
 
-#: src/msmtp.c:3497
+#: src/msmtp.c:3646
 #, c-format
 msgid "using account %s from %s\n"
 msgstr "uzas konton %s de %s\n"
 
-#: src/msmtp.c:3503 src/msmtp.c:3505 src/msmtp.c:3508 src/msmtp.c:3542
-#: src/msmtp.c:3543 src/msmtp.c:3545 src/msmtp.c:3547 src/msmtp.c:3551
-#: src/msmtp.c:3553 src/msmtp.c:3572 src/msmtp.c:3574 src/msmtp.c:3576
-#: src/msmtp.c:3586 src/msmtp.c:3589 src/msmtp.c:3591 src/msmtp.c:3596
-#: src/msmtp.c:3599 src/msmtp.c:3611 src/msmtp.c:3613 src/msmtp.c:3615
-#: src/msmtp.c:3618 src/msmtp.c:3620 src/msmtp.c:3622
+#: src/msmtp.c:3650 src/msmtp.c:3653 src/msmtp.c:3655 src/msmtp.c:3658
+#: src/msmtp.c:3692 src/msmtp.c:3693 src/msmtp.c:3695 src/msmtp.c:3697
+#: src/msmtp.c:3701 src/msmtp.c:3703 src/msmtp.c:3722 src/msmtp.c:3724
+#: src/msmtp.c:3726 src/msmtp.c:3736 src/msmtp.c:3739 src/msmtp.c:3741
+#: src/msmtp.c:3746 src/msmtp.c:3749 src/msmtp.c:3761 src/msmtp.c:3763
+#: src/msmtp.c:3765 src/msmtp.c:3768 src/msmtp.c:3770 src/msmtp.c:3772
 msgid "(not set)"
 msgstr "(ne elektita)"
 
-#: src/msmtp.c:3512
+#: src/msmtp.c:3662
 #, c-format
 msgid "off\n"
 msgstr "malŝaltita\n"
 
-#: src/msmtp.c:3518
+#: src/msmtp.c:3668
 #, c-format
 msgid "%d seconds\n"
 msgstr "%d sekundoj\n"
 
-#: src/msmtp.c:3522
+#: src/msmtp.c:3672
 #, c-format
 msgid "1 second\n"
 msgstr "1 sekundo\n"
 
-#: src/msmtp.c:3531
+#: src/msmtp.c:3681
 #, c-format
 msgid "none\n"
 msgstr "nenio\n"
 
-#: src/msmtp.c:3535
+#: src/msmtp.c:3685
 #, c-format
 msgid "choose\n"
 msgstr "elekti\n"
 
-#: src/msmtp.c:3548 src/msmtp.c:3549 src/msmtp.c:3578 src/msmtp.c:3594
-#: src/msmtp.c:3602 src/msmtp.c:3607 src/msmtp.c:3609
+#: src/msmtp.c:3698 src/msmtp.c:3699 src/msmtp.c:3728 src/msmtp.c:3744
+#: src/msmtp.c:3752 src/msmtp.c:3757 src/msmtp.c:3759
 msgid "on"
 msgstr "ŝaltita"
 
-#: src/msmtp.c:3548 src/msmtp.c:3549 src/msmtp.c:3578 src/msmtp.c:3594
-#: src/msmtp.c:3602 src/msmtp.c:3605 src/msmtp.c:3607 src/msmtp.c:3609
+#: src/msmtp.c:3698 src/msmtp.c:3699 src/msmtp.c:3728 src/msmtp.c:3744
+#: src/msmtp.c:3752 src/msmtp.c:3755 src/msmtp.c:3757 src/msmtp.c:3759
 msgid "off"
 msgstr "malŝaltita"
 
-#: src/msmtp.c:3599
+#: src/msmtp.c:3749
 msgid "(read from mail)"
 msgstr "(legi de retpoŝtaĵo)"
 
-#: src/msmtp.c:3601 src/msmtp.c:3604
+#: src/msmtp.c:3751 src/msmtp.c:3754
 msgid "auto"
 msgstr "aŭtomata"
 
-#: src/msmtp.c:3625
+#: src/msmtp.c:3775
 #, c-format
 msgid "reading recipients from the command line and the mail\n"
 msgstr "legas ricevontojn de la komandlinio kaj la retpoŝtaĵo\n"
 
-#: src/msmtp.c:3630
+#: src/msmtp.c:3780
 #, c-format
 msgid "reading recipients from the command line\n"
 msgstr "legas ricevontoj de la komandlinio\n"
 
-#: src/msmtp.c:3743
+#: src/msmtp.c:3894
 msgid "too many arguments"
 msgstr "tro da argumentoj"
 
-#: src/msmtp.c:3772
+#: src/msmtp.c:3924
 #, c-format
 msgid "envelope from address extracted from mail: %s\n"
 msgstr "envelope-from-retpoŝtadreso eltirita el la retpoŝtaĵo: %s\n"
 
-#: src/msmtp.c:3787
+#: src/msmtp.c:3939
 msgid "no recipients found"
 msgstr "neniuj ricevontoj trovitaj"
 
-#: src/msmtp.c:3817
+#: src/msmtp.c:3969
 #, c-format
 msgid "account chosen by envelope from address %s: %s\n"
 msgstr "konto elektita per envelope-from-retpoŝtadreso %s: %s\n"
 
-#: src/msmtp.c:3831
+#: src/msmtp.c:3983
 #, c-format
 msgid "falling back to default account\n"
 msgstr "anstataŭe uzas aprioran konton\n"
 
-#: src/msmtp.c:3854
+#: src/msmtp.c:4006
 #, c-format
 msgid "using environment variables EMAIL and SMTPSERVER\n"
 msgstr "uzas la medivariablojn EMAIL kaj SMTPSERVER\n"
 
-#: src/msmtp.c:3862
+#: src/msmtp.c:4014
 #, c-format
 msgid "account %s not found in %s and %s"
 msgstr "konto %s ne trovita en %s kaj %s"
 
-#: src/msmtp.c:3868 src/msmtp.c:3873
+#: src/msmtp.c:4020 src/msmtp.c:4025
 #, c-format
 msgid "account %s not found in %s"
 msgstr "konto %s ne trovita en %s"
 
-#: src/msmtp.c:3878
+#: src/msmtp.c:4030
 #, c-format
 msgid "account %s not found: no configuration file available"
 msgstr "konto %s ne trovita: neniu agordo-dosiero disponebla"
 
-#: src/msmtp.c:3893
+#: src/msmtp.c:4045
 #, c-format
 msgid "using account specified on command line\n"
 msgstr "uzas konton specifitan en la komandlinio\n"
 
-#: src/msmtp.c:3959
+#: src/msmtp.c:4110
 #, c-format
 msgid "account %s from %s: %s"
 msgstr "konto %s de %s: %s"
 
-#: src/msmtp.c:4000
+#: src/msmtp.c:4151
 msgid "this platform does not support syslog logging"
 msgstr "ĉi tiu platformo ne regas syslog-protokolado"
 
-#: src/msmtp.c:4009
+#: src/msmtp.c:4160
 #, c-format
 msgid "support for authentication method %s is not compiled in"
 msgstr "rego de aŭtentiga metodo %s ne disponeblas"
 
-#: src/msmtp.c:4017
+#: src/msmtp.c:4168
 #, c-format
 msgid "cannot initialize networking: %s"
 msgstr "ne eblas startigi reton: %s"
 
-#: src/msmtp.c:4028
+#: src/msmtp.c:4179
 #, c-format
 msgid "cannot initialize TLS library: %s"
 msgstr "ne eblas startigi TLS-bibliotekon: %s"
 
-#: src/msmtp.c:4035
+#: src/msmtp.c:4186
 msgid "support for TLS is not compiled in"
 msgstr "rego de TLS ne disponeblas"
 
-#: src/msmtp.c:4114
+#: src/msmtp.c:4272
 #, c-format
 msgid "LMTP server message: %s"
 msgstr "LMTP-servila mesaĝo: %s"
 
-#: src/msmtp.c:4125
+#: src/msmtp.c:4283
 #, c-format
 msgid "could not send mail to all recipients (account %s from %s)"
 msgstr "ne eblas sendi retpoŝtaĵon al ĉiuj ricevontoj (konto %s de %s)"
 
-#: src/msmtp.c:4131
+#: src/msmtp.c:4289
 msgid "could not send mail to all recipients"
 msgstr "ne eblas sendi retpoŝtaĵon al ĉiuj ricevontoj"
 
-#: src/msmtp.c:4146 src/msmtp.c:4201 src/msmtp.c:4222
+#: src/msmtp.c:4304 src/msmtp.c:4359 src/msmtp.c:4380
 #, c-format
 msgid "server message: %s"
 msgstr "servila mesaĝo: %s"
 
-#: src/msmtp.c:4152
+#: src/msmtp.c:4310
 #, c-format
 msgid "could not send mail (account %s from %s)"
 msgstr "ne eblas sendi retpoŝtaĵon (konto %s de %s)"
 
-#: src/msmtp.c:4157
+#: src/msmtp.c:4315
 msgid "could not send mail"
 msgstr "ne eblas sendi retpoŝtaĵon"
 
-#: src/msmtp.c:4167
+#: src/msmtp.c:4325
 #, c-format
 msgid "delivery to one or more recipients failed"
 msgstr "liverado al unu aŭ pli da ricevontoj malsukcesis"
@@ -1626,16 +1632,6 @@ msgstr "ne eblas konektiĝi al %s, pordo %d: %s"
 msgid "password for %s at %s: "
 msgstr "pasvorto por %s ĉe %s: "
 
-#: src/password.c:252
-#, c-format
-msgid "cannot evaluate '%s': %s"
-msgstr "'%s' ne estas taksebla: %s"
-
-#: src/password.c:262
-#, c-format
-msgid "cannot read output of '%s'"
-msgstr "ne eblas legi eligon de '%s'"
-
 #: src/smtp.c:208
 #, c-format
 msgid "the server sent an empty reply"
@@ -1770,3 +1766,11 @@ msgstr "la servilo ne kapablas plenumi la peton"
 #, c-format
 msgid "invalid argument for Remote Message Queue Starting"
 msgstr "nevalida argumento por RMQS"
+
+#, c-format
+#~ msgid "cannot evaluate '%s': %s"
+#~ msgstr "'%s' ne estas taksebla: %s"
+
+#, c-format
+#~ msgid "cannot read output of '%s'"
+#~ msgstr "ne eblas legi eligon de '%s'"

--- a/po/fr.po
+++ b/po/fr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: msmtp 1.8.18\n"
 "Report-Msgid-Bugs-To: marlam@marlam.de\n"
-"POT-Creation-Date: 2022-03-23 20:22+0100\n"
+"POT-Creation-Date: 2022-07-27 18:42+0200\n"
 "PO-Revision-Date: 2021-11-07 17:56+0100\n"
 "Last-Translator: Stéphane Aulery <lkppo@free.fr>\n"
 "Language-Team: French <traduc@traduc.org>\n"
@@ -41,7 +41,7 @@ msgstr "ligne %d : alias '%s' invalide"
 msgid "line %d: duplicate alias '%s'"
 msgstr "ligne %d : alias '%s' dupliqué"
 
-#: src/aliases.c:178 src/conf.c:1072 src/stream.c:63
+#: src/aliases.c:178 src/conf.c:1193 src/stream.c:63
 #, c-format
 msgid "input error"
 msgstr "erreur de lecture"
@@ -51,32 +51,32 @@ msgstr "erreur de lecture"
 msgid "Too many redirects when expanding alias %s."
 msgstr "Trop de redirection lors de la résolution de l'alias %s."
 
-#: src/conf.c:808 src/conf.c:823
+#: src/conf.c:815 src/conf.c:830
 #, c-format
 msgid "host not set"
 msgstr "nom de machine manquant"
 
-#: src/conf.c:813
+#: src/conf.c:820
 #, c-format
 msgid "port not set"
 msgstr "port non défini"
 
-#: src/conf.c:818
+#: src/conf.c:825
 #, c-format
 msgid "envelope-from address is missing"
 msgstr "adresse de l'expéditeur d'enveloppe est manquante"
 
-#: src/conf.c:828
+#: src/conf.c:835
 #, c-format
 msgid "tls_key_file requires tls_cert_file"
 msgstr "tls_key_file a besoin de tls_cert_file"
 
-#: src/conf.c:833
+#: src/conf.c:840
 #, c-format
 msgid "tls_cert_file requires tls_key_file"
 msgstr "tls_cert_file a besoin de tls_key_file"
 
-#: src/conf.c:841
+#: src/conf.c:848
 #, c-format
 msgid ""
 "tls requires either tls_trust_file (highly recommended) or tls_fingerprint "
@@ -85,75 +85,75 @@ msgstr ""
 "tls a besoin soit de tls_trust_file (vivement recommandé) ou de "
 "tls_fingerprint ou bien de désactiver tls_certcheck"
 
-#: src/conf.c:847
+#: src/conf.c:854
 #, c-format
 msgid "tls_crl_file requires tls_trust_file"
 msgstr "tls_crl_file a besoin de tls_trust_file"
 
-#: src/conf.c:879 src/conf.c:886 src/conf.c:903 src/mtls-gnutls.c:328
+#: src/conf.c:886 src/conf.c:893 src/conf.c:910 src/mtls-gnutls.c:328
 #, c-format
 msgid "%s: %s"
 msgstr "%s : %s"
 
-#: src/conf.c:1094
-#, c-format
-msgid "line longer than %d characters"
-msgstr "ligne supérieure à %d caractères"
-
-#: src/conf.c:1145 src/conf.c:1270
+#: src/conf.c:1119 src/conf.c:1292
 #, c-format
 msgid "line %d: missing account name"
 msgstr "ligne %d : nom de compte manquant"
 
-#: src/conf.c:1150
+#: src/conf.c:1124
 #, c-format
 msgid "line %d: account %s not (yet) defined"
 msgstr "ligne %d : compte %s non défini (à ce niveau)"
 
-#: src/conf.c:1242 src/conf.c:2060 src/conf.c:2077
+#: src/conf.c:1205
+#, c-format
+msgid "line longer than %d characters"
+msgstr "ligne supérieure à %d caractères"
+
+#: src/conf.c:1222 src/conf.c:1335 src/conf.c:1354 src/conf.c:1381
+#: src/conf.c:1410 src/conf.c:1718 src/conf.c:1753
+#, c-format
+msgid "line %d: command %s needs an argument"
+msgstr "ligne %d : la commande %s requiert un argument"
+
+#: src/conf.c:1264 src/conf.c:2103 src/conf.c:2120
 #, c-format
 msgid "line %d: command %s does not take an argument"
 msgstr "ligne %d : la commande %s ne prend pas d'argument"
 
-#: src/conf.c:1278
+#: src/conf.c:1300
 #, c-format
 msgid "line %d: an account name must not contain colons or commas"
 msgstr ""
 "ligne %d : un nom de compte ne doit pas contenir de deux-points(:) ni de "
 "virgule(,)"
 
-#: src/conf.c:1288
+#: src/conf.c:1310
 #, c-format
 msgid "line %d: account %s was already defined"
 msgstr "ligne %d : le compte %s était déjà défini"
 
-#: src/conf.c:1313 src/conf.c:1332 src/conf.c:1359 src/conf.c:1388
-#: src/conf.c:1695 src/conf.c:1730
-#, c-format
-msgid "line %d: command %s needs an argument"
-msgstr "ligne %d : la commande %s requiert un argument"
-
-#: src/conf.c:1343 src/conf.c:1375 src/conf.c:1406 src/conf.c:1440
-#: src/conf.c:1466 src/conf.c:1511 src/conf.c:1531 src/conf.c:1616
-#: src/conf.c:1637 src/conf.c:1656 src/conf.c:1717 src/conf.c:1748
-#: src/conf.c:1798 src/conf.c:1845 src/conf.c:1870 src/conf.c:1890
-#: src/conf.c:1910 src/conf.c:1930 src/conf.c:1977 src/conf.c:1998
-#: src/conf.c:2019 src/conf.c:2047
+#: src/conf.c:1365 src/conf.c:1397 src/conf.c:1428 src/conf.c:1462
+#: src/conf.c:1488 src/conf.c:1534 src/conf.c:1554 src/conf.c:1639
+#: src/conf.c:1660 src/conf.c:1679 src/conf.c:1740 src/conf.c:1771
+#: src/conf.c:1821 src/conf.c:1868 src/conf.c:1893 src/conf.c:1913
+#: src/conf.c:1933 src/conf.c:1953 src/conf.c:1973 src/conf.c:2020
+#: src/conf.c:2041 src/conf.c:2062 src/conf.c:2090
 #, c-format
 msgid "line %d: invalid argument %s for command %s"
 msgstr "ligne %d : argument %s invalide pour la commande %s"
 
-#: src/conf.c:2093
+#: src/conf.c:2136
 #, c-format
 msgid "line %d: unknown command %s"
 msgstr "ligne %d : commande %s inconnue"
 
-#: src/conf.c:2145
+#: src/conf.c:2190
 #, c-format
 msgid "contains secrets and therefore must be owned by you"
 msgstr "contient des mot de passe et doit donc vous appartenir"
 
-#: src/conf.c:2151
+#: src/conf.c:2196
 #, c-format
 msgid ""
 "contains secrets and therefore must have no more than user read/write "
@@ -164,101 +164,101 @@ msgstr ""
 
 #. TRANSLATORS: msmtp shares a lot of code and translatable strings with
 #. mpop <https://marlam.de/mpop>.
-#: src/msmtp.c:88
+#: src/msmtp.c:90
 #, c-format
 msgid "%s: FATAL: %s\n"
 msgstr "%s: FATAL: %s\n"
 
-#: src/msmtp.c:228 src/msmtp.c:406 src/msmtp.c:1401
+#: src/msmtp.c:230 src/msmtp.c:408 src/msmtp.c:1522
 #, c-format
 msgid "the server does not support TLS via the STARTTLS command"
 msgstr "le serveur ne supporte pas TLS via la commande STARTTLS"
 
-#: src/msmtp.c:270
+#: src/msmtp.c:272
 #, c-format
 msgid "the server does not support Remote Message Queue Starting"
 msgstr "le serveur ne supporte pas l'extension Remote Message Queue Starting"
 
-#: src/msmtp.c:282 src/msmtp.c:1459
+#: src/msmtp.c:284 src/msmtp.c:1580
 #, c-format
 msgid "the server does not support authentication"
 msgstr "le serveur ne supporte pas l'authentification"
 
-#: src/msmtp.c:441
+#: src/msmtp.c:443
 #, c-format
 msgid "%s server at %s (%s [%s]), port %d:\n"
 msgstr "serveur %s : %s (%s [%s]), port %d :\n"
 
-#: src/msmtp.c:447
+#: src/msmtp.c:450
 #, c-format
 msgid "%s server at %s (%s), port %d:\n"
 msgstr "serveur %s : %s (%s), port %d :\n"
 
-#: src/msmtp.c:453
+#: src/msmtp.c:457
 #, c-format
 msgid "%s server at %s ([%s]), port %d:\n"
 msgstr "serveur %s : %s ([%s]), port %d :\n"
 
-#: src/msmtp.c:459
+#: src/msmtp.c:464
 #, c-format
 msgid "%s server at %s, port %d:\n"
 msgstr "serveur %s : %s, port %d :\n"
 
-#: src/msmtp.c:479
+#: src/msmtp.c:485
 #, c-format
 msgid "No special capabilities.\n"
 msgstr "Pas de fonctionnalités particulières.\n"
 
-#: src/msmtp.c:483
+#: src/msmtp.c:489
 #, c-format
 msgid "Capabilities:\n"
 msgstr "Fonctionnalités :\n"
 
-#: src/msmtp.c:487
+#: src/msmtp.c:493
 msgid "Maximum message size is "
 msgstr "La taille maximum de message est "
 
-#: src/msmtp.c:490
+#: src/msmtp.c:496
 #, c-format
 msgid "unlimited\n"
 msgstr "infinie\n"
 
-#: src/msmtp.c:494
+#: src/msmtp.c:500
 #, c-format
 msgid "%ld bytes"
 msgstr "%ld octets"
 
-#: src/msmtp.c:497
+#: src/msmtp.c:503
 #, c-format
 msgid " = %.2f MiB"
 msgstr " = %.2f Mio"
 
-#: src/msmtp.c:502
+#: src/msmtp.c:508
 #, c-format
 msgid " = %.2f KiB"
 msgstr " = %.2f Kio"
 
-#: src/msmtp.c:509
+#: src/msmtp.c:515
 msgid "Support for command grouping for faster transmission"
 msgstr "Support du groupement de commandes pour une transmission plus rapide"
 
-#: src/msmtp.c:514
+#: src/msmtp.c:520
 msgid "Support for RMQS (Remote Message Queue Starting)"
 msgstr "Support du RMQS (Remote Message Queue Starting)"
 
-#: src/msmtp.c:519
+#: src/msmtp.c:525
 msgid "Support for Delivery Status Notifications"
 msgstr "Support de la notification de statut distribution (DSN)"
 
-#: src/msmtp.c:529
+#: src/msmtp.c:535
 msgid "Support for TLS encryption via the STARTTLS command"
 msgstr "Support du chiffrement TLS via la commande STARTTLS"
 
-#: src/msmtp.c:535
+#: src/msmtp.c:541
 msgid "Supported authentication methods:"
 msgstr "Méthodes d'authentification supportées :"
 
-#: src/msmtp.c:588
+#: src/msmtp.c:594
 #, c-format
 msgid ""
 "This server might advertise more or other capabilities when TLS is active.\n"
@@ -266,115 +266,115 @@ msgstr ""
 "Ce serveur pourrait annoncer des fonctionnalités différentes ou "
 "supplémentaires quand TLS est activé.\n"
 
-#: src/msmtp.c:1153 src/msmtp.c:3299
+#: src/msmtp.c:1274 src/msmtp.c:3447
 #, c-format
 msgid "cannot write mail headers to temporary file: output error"
 msgstr ""
 "impossible d'écrire les en-têtes de courriel dans le fichier temporaire : "
 "erreur d'écriture"
 
-#: src/msmtp.c:1261
+#: src/msmtp.c:1382
 #, c-format
 msgid "input error while reading the mail"
 msgstr "une erreur est survenue à la lecture du courriel"
 
-#: src/msmtp.c:1448
+#: src/msmtp.c:1569
 #, c-format
 msgid "the server does not support DSN"
 msgstr "le serveur ne supporte pas le DSN"
 
-#: src/msmtp.c:1597 src/msmtp.c:1616 src/msmtp.c:1668
+#: src/msmtp.c:1718 src/msmtp.c:1737 src/msmtp.c:1789
 #, c-format
 msgid "automatic configuration based on SRV records failed: %s"
 msgstr "configuration automatique basée sur l'enregistrement SRV échouée : %s"
 
-#: src/msmtp.c:1598
+#: src/msmtp.c:1719
 msgid "invalid mail address"
 msgstr "adresse électronique invalide"
 
-#: src/msmtp.c:1614
+#: src/msmtp.c:1735
 #, c-format
 msgid "no SRV records for %s or %s"
 msgstr "pas d'enregistrement SRV pour %s ou %s"
 
-#: src/msmtp.c:1631
+#: src/msmtp.c:1752
 #, c-format
 msgid "copy this to your configuration file %s"
 msgstr "copier dans le fichier de configuration %s"
 
-#: src/msmtp.c:1635
+#: src/msmtp.c:1756
 msgid "warning: the host does not match the mail domain; please check"
 msgstr ""
 "avertissement : l'hôte ne correspond pas au nom de domaine ; veuillez "
 "vérifier"
 
-#: src/msmtp.c:1638 src/msmtp.c:1642
+#: src/msmtp.c:1759 src/msmtp.c:1763
 msgid "add your password to the key ring:"
 msgstr "ajouter un mot de passe à la clef de l'anneau :"
 
-#: src/msmtp.c:1645
+#: src/msmtp.c:1766
 msgid "encrypt your password:"
 msgstr "chiffrement du mot de passe :"
 
-#: src/msmtp.c:1669
+#: src/msmtp.c:1790
 msgid "this system lacks libresolv"
 msgstr "libresolv n'est pas installée"
 
-#: src/msmtp.c:1896
+#: src/msmtp.c:2022
 #, c-format
 msgid "invalid logfile_time_format"
 msgstr "logfile_time_format invalide"
 
-#: src/msmtp.c:1909
+#: src/msmtp.c:2035
 #, c-format
 msgid "cannot open: %s"
 msgstr "erreur d'ouverture de fichier : %s"
 
-#: src/msmtp.c:1917
+#: src/msmtp.c:2043
 #, c-format
 msgid "cannot lock (tried for %d seconds): %s"
 msgstr "erreur de verrouillage de fichier (attende de %d secondes) : %s"
 
-#: src/msmtp.c:1922
+#: src/msmtp.c:2048
 #, c-format
 msgid "cannot lock: %s"
 msgstr "erreur de verrouillage de fichier : %s"
 
-#: src/msmtp.c:1931
+#: src/msmtp.c:2057
 msgid "output error"
 msgstr "erreur d'écriture"
 
-#: src/msmtp.c:1948
+#: src/msmtp.c:2074
 #, c-format
 msgid "cannot log to %s: %s"
 msgstr "impossible d'écrire dans le journal %s : %s"
 
-#: src/msmtp.c:1952
+#: src/msmtp.c:2078
 #, c-format
 msgid "log info was: %s"
 msgstr "l'entrée du journal était : %s"
 
-#: src/msmtp.c:2061
+#: src/msmtp.c:2187
 #, c-format
 msgid "%s version %s\n"
 msgstr "%s version %s\n"
 
-#: src/msmtp.c:2062
+#: src/msmtp.c:2188
 #, c-format
 msgid "Platform: %s\n"
 msgstr "Plateforme : %s\n"
 
-#: src/msmtp.c:2064
+#: src/msmtp.c:2190
 #, c-format
 msgid "TLS/SSL library: %s\n"
 msgstr "Librairie TLS/SSL : %s\n"
 
-#: src/msmtp.c:2072 src/msmtp.c:2150
+#: src/msmtp.c:2198 src/msmtp.c:2276
 #, c-format
 msgid "none"
 msgstr "aucun(e)"
 
-#: src/msmtp.c:2076
+#: src/msmtp.c:2202
 #, c-format
 msgid ""
 "Authentication library: %s\n"
@@ -383,65 +383,65 @@ msgstr ""
 "Librairie d'authentification : %s\n"
 "Méthodes d'authentification supportées :\n"
 
-#: src/msmtp.c:2079
+#: src/msmtp.c:2205
 msgid "GNU SASL; oauthbearer and xoauth2: built-in"
 msgstr "GNU SASL ; oauthbearer et xoauth2 : built-in"
 
-#: src/msmtp.c:2081
+#: src/msmtp.c:2207
 msgid "built-in"
 msgstr "intégrée"
 
-#: src/msmtp.c:2130
+#: src/msmtp.c:2256
 #, c-format
 msgid "IDN support: "
 msgstr "Support IDN : "
 
-#: src/msmtp.c:2134 src/msmtp.c:2142
+#: src/msmtp.c:2260 src/msmtp.c:2268
 #, c-format
 msgid "enabled"
 msgstr "activé"
 
-#: src/msmtp.c:2136 src/msmtp.c:2145
+#: src/msmtp.c:2262 src/msmtp.c:2271
 #, c-format
 msgid "disabled"
 msgstr "désactivé"
 
-#: src/msmtp.c:2140
+#: src/msmtp.c:2266
 #, c-format
 msgid "NLS: "
 msgstr "NLS: "
 
-#: src/msmtp.c:2143
+#: src/msmtp.c:2269
 #, c-format
 msgid ", LOCALEDIR is %s"
 msgstr ", LOCALEDIR : %s"
 
-#: src/msmtp.c:2148
+#: src/msmtp.c:2274
 #, c-format
 msgid "Keyring support: "
 msgstr "Support de porte-clés : "
 
-#: src/msmtp.c:2153
+#: src/msmtp.c:2279
 #, c-format
 msgid "Gnome "
 msgstr "Gnome "
 
-#: src/msmtp.c:2156
+#: src/msmtp.c:2282
 #, c-format
 msgid "MacOS "
 msgstr "MacOS "
 
-#: src/msmtp.c:2162
+#: src/msmtp.c:2288
 #, c-format
 msgid "System configuration file name: %s\n"
 msgstr "Nom du fichier de configuration système : %s\n"
 
-#: src/msmtp.c:2166
+#: src/msmtp.c:2292
 #, c-format
 msgid "User configuration file name: %s\n"
 msgstr "Nom du fichier de configuration utilisateur : %s\n"
 
-#: src/msmtp.c:2169
+#: src/msmtp.c:2295
 #, c-format
 msgid ""
 "Copyright (C) %d Martin Lambers and others.\n"
@@ -458,7 +458,7 @@ msgstr ""
 "Ce programme est distribué SANS AUCUNE GARANTIE, dans les limites permises "
 "par la loi.\n"
 
-#: src/msmtp.c:2186
+#: src/msmtp.c:2312
 #, c-format
 msgid ""
 "Usage:\n"
@@ -467,7 +467,7 @@ msgstr ""
 "Usage :\n"
 "\n"
 
-#: src/msmtp.c:2187
+#: src/msmtp.c:2313
 #, c-format
 msgid ""
 "Sendmail mode (default):\n"
@@ -482,7 +482,7 @@ msgstr ""
 "  Lit un courriel depuis l'entrée standard et le transmet à un serveur SMTP "
 "ou LMTP.\n"
 
-#: src/msmtp.c:2192
+#: src/msmtp.c:2318
 #, c-format
 msgid ""
 "Configuration mode:\n"
@@ -493,7 +493,7 @@ msgstr ""
 "  %s --configure=email\n"
 "  Génération et affichage de la configuration de l'email.\n"
 
-#: src/msmtp.c:2195
+#: src/msmtp.c:2321
 #, c-format
 msgid ""
 "Server information mode:\n"
@@ -504,7 +504,7 @@ msgstr ""
 "  %s [option...] --serverinfo\n"
 "  Affiche les informations sur le serveur.\n"
 
-#: src/msmtp.c:2198
+#: src/msmtp.c:2324
 #, c-format
 msgid ""
 "Remote Message Queue Starting mode:\n"
@@ -517,40 +517,40 @@ msgstr ""
 "  Envoie une requête Remote Message Queue Starting à un serveur.\n"
 "\n"
 
-#: src/msmtp.c:2202
+#: src/msmtp.c:2328
 #, c-format
 msgid "General options:\n"
 msgstr "Option Générales :\n"
 
-#: src/msmtp.c:2203
+#: src/msmtp.c:2329
 #, c-format
 msgid "  --version                    print version\n"
 msgstr "  --version                    affiche la version\n"
 
-#: src/msmtp.c:2204
+#: src/msmtp.c:2330
 #, c-format
 msgid "  --help                       print help\n"
 msgstr "  --help                       affiche l'aide\n"
 
-#: src/msmtp.c:2205
+#: src/msmtp.c:2331
 #, c-format
 msgid "  -P, --pretend                print configuration info and exit\n"
 msgstr ""
 "  -P, --pretend                affiche les informations de configuration et "
 "quitte\n"
 
-#: src/msmtp.c:2206
+#: src/msmtp.c:2332
 #, c-format
 msgid "  -d, --debug                  print debugging information\n"
 msgstr ""
 "  -d, --debug                  affiche les informations de déverminage\n"
 
-#: src/msmtp.c:2207
+#: src/msmtp.c:2333
 #, c-format
 msgid "Changing the mode of operation:\n"
 msgstr "Changement de mode d'opération :\n"
 
-#: src/msmtp.c:2208
+#: src/msmtp.c:2334
 #, c-format
 msgid ""
 "  --configure=mailaddress      generate and print configuration for address\n"
@@ -558,13 +558,13 @@ msgstr ""
 "  --configure=email            génére et affiche une configuration pour "
 "l'email\n"
 
-#: src/msmtp.c:2209
+#: src/msmtp.c:2335
 #, c-format
 msgid "  -S, --serverinfo             print information about the server\n"
 msgstr ""
 "  -S, --serverinfo             affiche les informations sur le serveur\n"
 
-#: src/msmtp.c:2210
+#: src/msmtp.c:2336
 #, c-format
 msgid ""
 "  --rmqs=host|@domain|#queue   send a Remote Message Queue Starting request\n"
@@ -572,18 +572,18 @@ msgstr ""
 "  --rmqs=host|@domain|#queue   envoie une requête Remote Message Queue "
 "Starting\n"
 
-#: src/msmtp.c:2211
+#: src/msmtp.c:2337
 #, c-format
 msgid "Configuration options:\n"
 msgstr "Options de configuration :\n"
 
-#: src/msmtp.c:2212
+#: src/msmtp.c:2338
 #, c-format
 msgid "  -C, --file=filename          set configuration file\n"
 msgstr ""
 "  -C, --file=filename          spécifie le nom du fichier de configuration\n"
 
-#: src/msmtp.c:2213
+#: src/msmtp.c:2339
 #, c-format
 msgid ""
 "  -a, --account=id             use the given account instead of the account\n"
@@ -596,7 +596,7 @@ msgstr ""
 "changés\n"
 "                               avec les options de la ligne de commande\n"
 
-#: src/msmtp.c:2216
+#: src/msmtp.c:2342
 #, c-format
 msgid ""
 "  --host=hostname              set the server, use only command-line "
@@ -608,12 +608,12 @@ msgstr ""
 "                               aucune donnée du fichier de configuration ne "
 "sera utilisée\n"
 
-#: src/msmtp.c:2218
+#: src/msmtp.c:2344
 #, c-format
 msgid "  --port=number                set port number\n"
 msgstr "  --port=number                spécifie le numéro de port\n"
 
-#: src/msmtp.c:2219
+#: src/msmtp.c:2345
 #, c-format
 msgid ""
 "  --source-ip=[IP]             set/unset source ip address to bind the "
@@ -622,37 +622,37 @@ msgstr ""
 "  --source-ip=[IP]             spécifie l'adresse IP source à laquelle "
 "affecter la socket\n"
 
-#: src/msmtp.c:2220
+#: src/msmtp.c:2346
 #, c-format
 msgid "  --proxy-host=[IP|hostname]   set/unset proxy\n"
 msgstr "  --proxy-host=[IP|hostname]   spécifie le serveur mandataire\n"
 
-#: src/msmtp.c:2221
+#: src/msmtp.c:2347
 #, c-format
 msgid "  --proxy-port=[number]        set/unset proxy port\n"
 msgstr ""
 "  --proxy-port=[number]        spécifie le port du serveur mandataire\n"
 
-#: src/msmtp.c:2222
+#: src/msmtp.c:2348
 #, c-format
 msgid "  --socket=[socketname]        set/unset local socket to connect to\n"
 msgstr ""
 "  --socket=[socketname]        spécifie le nom du socket auquel se "
 "connecter\n"
 
-#: src/msmtp.c:2223
+#: src/msmtp.c:2349
 #, c-format
 msgid "  --timeout=(off|seconds)      set/unset network timeout in seconds\n"
 msgstr ""
 "  --timeout=(off|seconds)      défini/désactive le délai d'inactivité réseau "
 "en secondes\n"
 
-#: src/msmtp.c:2224
+#: src/msmtp.c:2350
 #, c-format
 msgid "  --protocol=(smtp|lmtp)       use the given sub protocol\n"
 msgstr "  --protocol=(smtp|lmtp)       utilise le protocole donné\n"
 
-#: src/msmtp.c:2225
+#: src/msmtp.c:2351
 #, c-format
 msgid ""
 "  --domain=string              set the argument of EHLO or LHLO command\n"
@@ -660,7 +660,7 @@ msgstr ""
 "  --domain=string              spécifie l'argument des commandes EHLO ou "
 "LHLO\n"
 
-#: src/msmtp.c:2226
+#: src/msmtp.c:2352
 #, c-format
 msgid ""
 "  --auth[=(on|off|method)]     enable/disable authentication and optionally\n"
@@ -669,41 +669,41 @@ msgstr ""
 "  --auth[=(on|off|method)]     active, désactive ou spécifie la méthode\n"
 "                               d'authentification\n"
 
-#: src/msmtp.c:2228
+#: src/msmtp.c:2354
 #, c-format
 msgid "  --user=[username]            set/unset user name for authentication\n"
 msgstr ""
 "  --user=[username]            spécifie le nom d'utilisateur pour "
 "l'authentification\n"
 
-#: src/msmtp.c:2229
+#: src/msmtp.c:2355
 #, c-format
 msgid "  --passwordeval=[eval]        evaluate password for authentication\n"
 msgstr ""
 "  --passwordeval=[eval]        évalue le mot de passe pour "
 "l'authentification\n"
 
-#: src/msmtp.c:2230
+#: src/msmtp.c:2356
 #, c-format
 msgid "  --tls[=(on|off)]             enable/disable TLS encryption\n"
 msgstr "  --tls[=(on|off)]             active/désactive le chiffrement TLS\n"
 
-#: src/msmtp.c:2231
+#: src/msmtp.c:2357
 #, c-format
 msgid "  --tls-starttls[=(on|off)]    enable/disable STARTTLS for TLS\n"
 msgstr "  --tls-starttls[=(on|off)]    active/désactive STARTTLS pour TLS\n"
 
-#: src/msmtp.c:2232
+#: src/msmtp.c:2358
 #, c-format
 msgid "  --tls-trust-file=[file]      set/unset trust file for TLS\n"
 msgstr "  --tls-trust-file=[file]      spécifie le fichier de confiance TLS\n"
 
-#: src/msmtp.c:2233
+#: src/msmtp.c:2359
 #, c-format
 msgid "  --tls-crl-file=[file]        set/unset revocation file for TLS\n"
 msgstr "  --tls-crl-file=[file]        spécifie le fichier de révocation TLS\n"
 
-#: src/msmtp.c:2234
+#: src/msmtp.c:2360
 #, c-format
 msgid ""
 "  --tls-fingerprint=[f]        set/unset trusted certificate fingerprint for "
@@ -712,7 +712,7 @@ msgstr ""
 "  --tls-fingerprint=[f]        spécifie l'empreinte du certificat de "
 "confiance TLS\n"
 
-#: src/msmtp.c:2235
+#: src/msmtp.c:2361
 #, c-format
 msgid ""
 "  --tls-certcheck[=(on|off)]   enable/disable server certificate checks for "
@@ -721,26 +721,26 @@ msgstr ""
 "  --tls-certcheck[=(on|off)]   active/désactive la vérification des "
 "certificats serveur TLS\n"
 
-#: src/msmtp.c:2236
+#: src/msmtp.c:2362
 #, c-format
 msgid "  --tls-key-file=[file]        set/unset private key file for TLS\n"
 msgstr ""
 "  --tls-key-file=[file]        spécifie le fichier contenant la clé privée "
 "TLS\n"
 
-#: src/msmtp.c:2237
+#: src/msmtp.c:2363
 #, c-format
 msgid "  --tls-cert-file=[file]       set/unset private cert file for TLS\n"
 msgstr ""
 "  --tls-cert-file=[file]       spécifie le fichier contenant le certificat "
 "privé TLS\n"
 
-#: src/msmtp.c:2238
+#: src/msmtp.c:2364
 #, c-format
 msgid "  --tls-priorities=[prios]     set/unset TLS priorities.\n"
 msgstr "  --tls-priorities=[prios]     active les priorités TLS.\n"
 
-#: src/msmtp.c:2239
+#: src/msmtp.c:2365
 #, c-format
 msgid ""
 "  --tls-host-override=[host]   set/unset override for TLS host "
@@ -749,19 +749,19 @@ msgstr ""
 "  --tls-host-override=[host]   active l'écrasement de la vérification d'un "
 "hôte TLS.\n"
 
-#: src/msmtp.c:2240
+#: src/msmtp.c:2366
 #, c-format
 msgid "  --tls-min-dh-prime-bits=[b]  set/unset minimum bit size of DH prime\n"
 msgstr ""
 "  --tls-min-dh-prime-bits=[b]  spécifie/désactive le nombre minimum de bits "
 "utilisés pour le nombre premier DH\n"
 
-#: src/msmtp.c:2241
+#: src/msmtp.c:2367
 #, c-format
 msgid "Options specific to sendmail mode:\n"
 msgstr "Options spécifiques au mode sendmail :\n"
 
-#: src/msmtp.c:2242
+#: src/msmtp.c:2368
 #, c-format
 msgid ""
 "  --auto-from[=(on|off)]       enable/disable automatic envelope-from "
@@ -770,14 +770,14 @@ msgstr ""
 "  --auto-from[=(on|off)]       active/désactive le remplissage automatique "
 "du champ \"From\" de l'enveloppe\n"
 
-#: src/msmtp.c:2243
+#: src/msmtp.c:2369
 #, c-format
 msgid "  -f, --from=address           set envelope from address\n"
 msgstr ""
 "  -f, --from=address           spécifie l'adresse de l'expéditeur de "
 "l'enveloppe\n"
 
-#: src/msmtp.c:2244
+#: src/msmtp.c:2370
 #, c-format
 msgid ""
 "  --maildomain=[domain]        set the domain for automatic envelope from\n"
@@ -787,25 +787,25 @@ msgstr ""
 "automatique de l'adresse \n"
 "                               de l'expéditeur d'enveloppe\n"
 
-#: src/msmtp.c:2246
+#: src/msmtp.c:2372
 #, c-format
 msgid "  -N, --dsn-notify=(off|cond)  set/unset DSN conditions\n"
 msgstr ""
 "  -N, --dsn-notify=(off|cond)  spécifie/désactive les conditions de DSN\n"
 
-#: src/msmtp.c:2247
+#: src/msmtp.c:2373
 #, c-format
 msgid "  -R, --dsn-return=(off|ret)   set/unset DSN amount\n"
 msgstr ""
 "  -R, --dsn-return=(off|ret)   spécifie la quantité à renvoyer dans la DSN "
 "(off/headers/full)\n"
 
-#: src/msmtp.c:2248
+#: src/msmtp.c:2374
 #, c-format
 msgid "  -X, --logfile=[file]         set/unset log file\n"
 msgstr "  -X, --logfile=[file]         spécifie le fichier journal\n"
 
-#: src/msmtp.c:2249
+#: src/msmtp.c:2375
 #, c-format
 msgid ""
 "  --logfile-time-format=[fmt]  set/unset log file time format for "
@@ -814,13 +814,13 @@ msgstr ""
 "  --logfile-time-format=[fmt]  définir le format de date strftime() du "
 "fichier journal\n"
 
-#: src/msmtp.c:2250
+#: src/msmtp.c:2376
 #, c-format
 msgid ""
 "  --syslog[=(on|off|facility)] enable/disable/configure syslog logging\n"
 msgstr "  --syslog[=(on|off|facility)] active/désactive/configure syslog\n"
 
-#: src/msmtp.c:2251
+#: src/msmtp.c:2377
 #, c-format
 msgid ""
 "  -t, --read-recipients        read additional recipients from the mail\n"
@@ -828,7 +828,7 @@ msgstr ""
 "  -t, --read-recipients        lit les destinataires supplémentaires depuis "
 "le courriel\n"
 
-#: src/msmtp.c:2252
+#: src/msmtp.c:2378
 #, c-format
 msgid ""
 "  --read-envelope-from         read envelope from address from the mail\n"
@@ -836,22 +836,28 @@ msgstr ""
 "  --read-envelope-from         lit l'adresse d'expéditeur de l'enveloppe "
 "depuis le courriel\n"
 
-#: src/msmtp.c:2253
+#: src/msmtp.c:2379
 #, c-format
 msgid "  --aliases=[file]             set/unset aliases file\n"
 msgstr "  --aliases=[file]             spécifie le fichier d'alias\n"
 
-#: src/msmtp.c:2254
+#: src/msmtp.c:2380
 #, c-format
 msgid "  --set-from-header[=(auto|on|off)] set From header handling\n"
 msgstr "  --set-from-header[=(auto|on|off)] gestion de l'entête From\n"
 
-#: src/msmtp.c:2255
+#: src/msmtp.c:2381
 #, c-format
 msgid "  --set-date-header[=(auto|off)] set Date header handling\n"
 msgstr "  --set-date-header[=(auto|off)] gestion de l'entête Date\n"
 
-#: src/msmtp.c:2256
+#: src/msmtp.c:2382
+#, fuzzy, c-format
+#| msgid "  --set-date-header[=(auto|off)] set Date header handling\n"
+msgid "  --set-msgid-header[=(auto|off)] set Message-ID header handling\n"
+msgstr "  --set-date-header[=(auto|off)] gestion de l'entête Date\n"
+
+#: src/msmtp.c:2383
 #, c-format
 msgid ""
 "  --remove-bcc-headers[=(on|off)] enable/disable removal of Bcc headers\n"
@@ -859,7 +865,7 @@ msgstr ""
 "  --remove-bcc-headers[=(on|off)] active/désactive la suppression des "
 "entêtes Bcc\n"
 
-#: src/msmtp.c:2257
+#: src/msmtp.c:2384
 #, c-format
 msgid ""
 "  --undisclosed-recipients[=(on|off)] enable/disable replacement of To/Cc/"
@@ -870,12 +876,12 @@ msgstr ""
 "Cc/Bcc\n"
 "                               par To: undisclosed-recipients:;\n"
 
-#: src/msmtp.c:2259
+#: src/msmtp.c:2386
 #, c-format
 msgid "  --                           end of options\n"
 msgstr "  --                           fin des options\n"
 
-#: src/msmtp.c:2260
+#: src/msmtp.c:2387
 #, c-format
 msgid ""
 "Accepted but ignored: -A, -B, -bm, -F, -G, -h, -i, -L, -m, -n, -O, -o, -v\n"
@@ -883,7 +889,7 @@ msgstr ""
 "Acceptées mais ignorées : -A, -B, -bm, -F, -G, -h, -i, -L, -m, -n, -O, -o, -"
 "v\n"
 
-#: src/msmtp.c:2261
+#: src/msmtp.c:2388
 #, c-format
 msgid ""
 "\n"
@@ -892,238 +898,238 @@ msgstr ""
 "\n"
 "Soumettre les bogues à <%s>.\n"
 
-#: src/msmtp.c:2503 src/msmtp.c:2517
+#: src/msmtp.c:2633 src/msmtp.c:2647
 msgid "cannot use both --serverinfo and --rmqs"
 msgstr "les options --serverinfo et --rmqs sont mutuellement exclusives"
 
-#: src/msmtp.c:2537 src/msmtp.c:2549
+#: src/msmtp.c:2667 src/msmtp.c:2679
 msgid "cannot use both --host and --account"
 msgstr "les options --host et --account sont mutuellement exclusives"
 
-#: src/msmtp.c:2565 src/msmtp.c:2583 src/msmtp.c:2602 src/msmtp.c:2657
-#: src/msmtp.c:2689 src/msmtp.c:2707 src/msmtp.c:2770 src/msmtp.c:2815
-#: src/msmtp.c:2837 src/msmtp.c:2883 src/msmtp.c:2908 src/msmtp.c:2927
-#: src/msmtp.c:2980 src/msmtp.c:3025 src/msmtp.c:3052 src/msmtp.c:3070
-#: src/msmtp.c:3089 src/msmtp.c:3108 src/msmtp.c:3126 src/msmtp.c:3144
-#: src/msmtp.c:3221
+#: src/msmtp.c:2695 src/msmtp.c:2713 src/msmtp.c:2732 src/msmtp.c:2787
+#: src/msmtp.c:2819 src/msmtp.c:2837 src/msmtp.c:2900 src/msmtp.c:2945
+#: src/msmtp.c:2967 src/msmtp.c:3013 src/msmtp.c:3038 src/msmtp.c:3057
+#: src/msmtp.c:3110 src/msmtp.c:3155 src/msmtp.c:3182 src/msmtp.c:3200
+#: src/msmtp.c:3218 src/msmtp.c:3237 src/msmtp.c:3256 src/msmtp.c:3274
+#: src/msmtp.c:3292 src/msmtp.c:3369
 #, c-format
 msgid "invalid argument %s for %s"
 msgstr "argument %s invalide pour %s"
 
-#: src/msmtp.c:2612 src/msmtp.c:3184
+#: src/msmtp.c:2742 src/msmtp.c:3332
 msgid "cannot use both --from and --read-envelope-from"
 msgstr ""
 "les options --from et --read-envelope-from sont mutuellement exclusives"
 
-#: src/msmtp.c:3199
+#: src/msmtp.c:3347
 #, c-format
 msgid "unsupported operation mode b%s"
 msgstr "le mode d'opération b%s n'est pas supporté"
 
-#: src/msmtp.c:3276 src/msmtp.c:3753 src/msmtp.c:4052
+#: src/msmtp.c:3424 src/msmtp.c:3904 src/msmtp.c:4204
 #, c-format
 msgid "cannot create temporary file: %s"
 msgstr "erreur de création de fichier temporaire : %s"
 
-#: src/msmtp.c:3306 src/msmtp.c:3778 src/msmtp.c:4085
+#: src/msmtp.c:3454 src/msmtp.c:3930 src/msmtp.c:4243
 #, c-format
 msgid "cannot rewind temporary file: %s"
 msgstr "erreur de retour au début du fichier temporaire : %s"
 
-#: src/msmtp.c:3371
+#: src/msmtp.c:3520
 #, c-format
 msgid "ignoring system configuration file %s: %s\n"
 msgstr "le fichier de configuration système %s est ignoré : %s\n"
 
-#: src/msmtp.c:3386
+#: src/msmtp.c:3535
 #, c-format
 msgid "loaded system configuration file %s\n"
 msgstr "le fichier de configuration système %s est chargé\n"
 
-#: src/msmtp.c:3425
+#: src/msmtp.c:3574
 #, c-format
 msgid "ignoring user configuration file %s: %s\n"
 msgstr "le fichier de configuration utilisateur %s est ignoré : %s\n"
 
-#: src/msmtp.c:3440
+#: src/msmtp.c:3589
 #, c-format
 msgid "loaded user configuration file %s\n"
 msgstr "le fichier de configuration utilisateur %s est chargé\n"
 
-#: src/msmtp.c:3497
+#: src/msmtp.c:3646
 #, c-format
 msgid "using account %s from %s\n"
 msgstr "utilisation du compte %s depuis %s\n"
 
-#: src/msmtp.c:3503 src/msmtp.c:3505 src/msmtp.c:3508 src/msmtp.c:3542
-#: src/msmtp.c:3543 src/msmtp.c:3545 src/msmtp.c:3547 src/msmtp.c:3551
-#: src/msmtp.c:3553 src/msmtp.c:3572 src/msmtp.c:3574 src/msmtp.c:3576
-#: src/msmtp.c:3586 src/msmtp.c:3589 src/msmtp.c:3591 src/msmtp.c:3596
-#: src/msmtp.c:3599 src/msmtp.c:3611 src/msmtp.c:3613 src/msmtp.c:3615
-#: src/msmtp.c:3618 src/msmtp.c:3620 src/msmtp.c:3622
+#: src/msmtp.c:3650 src/msmtp.c:3653 src/msmtp.c:3655 src/msmtp.c:3658
+#: src/msmtp.c:3692 src/msmtp.c:3693 src/msmtp.c:3695 src/msmtp.c:3697
+#: src/msmtp.c:3701 src/msmtp.c:3703 src/msmtp.c:3722 src/msmtp.c:3724
+#: src/msmtp.c:3726 src/msmtp.c:3736 src/msmtp.c:3739 src/msmtp.c:3741
+#: src/msmtp.c:3746 src/msmtp.c:3749 src/msmtp.c:3761 src/msmtp.c:3763
+#: src/msmtp.c:3765 src/msmtp.c:3768 src/msmtp.c:3770 src/msmtp.c:3772
 msgid "(not set)"
 msgstr "(non défini)"
 
-#: src/msmtp.c:3512
+#: src/msmtp.c:3662
 #, c-format
 msgid "off\n"
 msgstr "désactivé\n"
 
-#: src/msmtp.c:3518
+#: src/msmtp.c:3668
 #, c-format
 msgid "%d seconds\n"
 msgstr "%d secondes\n"
 
-#: src/msmtp.c:3522
+#: src/msmtp.c:3672
 #, c-format
 msgid "1 second\n"
 msgstr "1 seconde\n"
 
-#: src/msmtp.c:3531
+#: src/msmtp.c:3681
 #, c-format
 msgid "none\n"
 msgstr "aucun\n"
 
-#: src/msmtp.c:3535
+#: src/msmtp.c:3685
 #, c-format
 msgid "choose\n"
 msgstr "automatique\n"
 
-#: src/msmtp.c:3548 src/msmtp.c:3549 src/msmtp.c:3578 src/msmtp.c:3594
-#: src/msmtp.c:3602 src/msmtp.c:3607 src/msmtp.c:3609
+#: src/msmtp.c:3698 src/msmtp.c:3699 src/msmtp.c:3728 src/msmtp.c:3744
+#: src/msmtp.c:3752 src/msmtp.c:3757 src/msmtp.c:3759
 msgid "on"
 msgstr "activé"
 
-#: src/msmtp.c:3548 src/msmtp.c:3549 src/msmtp.c:3578 src/msmtp.c:3594
-#: src/msmtp.c:3602 src/msmtp.c:3605 src/msmtp.c:3607 src/msmtp.c:3609
+#: src/msmtp.c:3698 src/msmtp.c:3699 src/msmtp.c:3728 src/msmtp.c:3744
+#: src/msmtp.c:3752 src/msmtp.c:3755 src/msmtp.c:3757 src/msmtp.c:3759
 msgid "off"
 msgstr "désactivé"
 
-#: src/msmtp.c:3599
+#: src/msmtp.c:3749
 msgid "(read from mail)"
 msgstr "(lu depuis le courriel)"
 
-#: src/msmtp.c:3601 src/msmtp.c:3604
+#: src/msmtp.c:3751 src/msmtp.c:3754
 msgid "auto"
 msgstr "auto"
 
-#: src/msmtp.c:3625
+#: src/msmtp.c:3775
 #, c-format
 msgid "reading recipients from the command line and the mail\n"
 msgstr "lecture des destinataires depuis la ligne de commande et le courriel\n"
 
-#: src/msmtp.c:3630
+#: src/msmtp.c:3780
 #, c-format
 msgid "reading recipients from the command line\n"
 msgstr "lecture des destinataires depuis la ligne de commande\n"
 
-#: src/msmtp.c:3743
+#: src/msmtp.c:3894
 msgid "too many arguments"
 msgstr "trop d'arguments"
 
-#: src/msmtp.c:3772
+#: src/msmtp.c:3924
 #, c-format
 msgid "envelope from address extracted from mail: %s\n"
 msgstr "adresse de l'expéditeur d'enveloppe extraite du courriel : %s\n"
 
-#: src/msmtp.c:3787
+#: src/msmtp.c:3939
 msgid "no recipients found"
 msgstr "aucun destinataire trouvé"
 
-#: src/msmtp.c:3817
+#: src/msmtp.c:3969
 #, c-format
 msgid "account chosen by envelope from address %s: %s\n"
 msgstr "compte sélectionné via l'adresse de l'expéditeur d'enveloppe %s : %s\n"
 
-#: src/msmtp.c:3831
+#: src/msmtp.c:3983
 #, c-format
 msgid "falling back to default account\n"
 msgstr "repli sur le compte par défaut\n"
 
-#: src/msmtp.c:3854
+#: src/msmtp.c:4006
 #, c-format
 msgid "using environment variables EMAIL and SMTPSERVER\n"
 msgstr "utilisation des variables d'environnement EMAIL et SMTPSERVER\n"
 
-#: src/msmtp.c:3862
+#: src/msmtp.c:4014
 #, c-format
 msgid "account %s not found in %s and %s"
 msgstr "compte %s introuvable dans %s et %s"
 
-#: src/msmtp.c:3868 src/msmtp.c:3873
+#: src/msmtp.c:4020 src/msmtp.c:4025
 #, c-format
 msgid "account %s not found in %s"
 msgstr "compte %s introuvable dans %s"
 
-#: src/msmtp.c:3878
+#: src/msmtp.c:4030
 #, c-format
 msgid "account %s not found: no configuration file available"
 msgstr "compte %s introuvable : aucun fichier de configuration disponible"
 
-#: src/msmtp.c:3893
+#: src/msmtp.c:4045
 #, c-format
 msgid "using account specified on command line\n"
 msgstr "utilisation du compte spécifié sur la ligne de commande\n"
 
-#: src/msmtp.c:3959
+#: src/msmtp.c:4110
 #, c-format
 msgid "account %s from %s: %s"
 msgstr "compte %s depuis %s : %s"
 
-#: src/msmtp.c:4000
+#: src/msmtp.c:4151
 msgid "this platform does not support syslog logging"
 msgstr "cette plateforme de supporte pas la journalisation par syslog"
 
-#: src/msmtp.c:4009
+#: src/msmtp.c:4160
 #, c-format
 msgid "support for authentication method %s is not compiled in"
 msgstr "le support de la méthode d'authentification %s n'est pas compilé"
 
-#: src/msmtp.c:4017
+#: src/msmtp.c:4168
 #, c-format
 msgid "cannot initialize networking: %s"
 msgstr "erreur d'initialisation réseau : %s"
 
-#: src/msmtp.c:4028
+#: src/msmtp.c:4179
 #, c-format
 msgid "cannot initialize TLS library: %s"
 msgstr "erreur d'initialisation de la librairie TLS : %s"
 
-#: src/msmtp.c:4035
+#: src/msmtp.c:4186
 msgid "support for TLS is not compiled in"
 msgstr "le support de TLS n'est pas compilé"
 
-#: src/msmtp.c:4114
+#: src/msmtp.c:4272
 #, c-format
 msgid "LMTP server message: %s"
 msgstr "Message du serveur LMTP : %s"
 
-#: src/msmtp.c:4125
+#: src/msmtp.c:4283
 #, c-format
 msgid "could not send mail to all recipients (account %s from %s)"
 msgstr ""
 "le courriel n'a pas pu être envoyé à tous les destinataires (compte %s dans "
 "%s)"
 
-#: src/msmtp.c:4131
+#: src/msmtp.c:4289
 msgid "could not send mail to all recipients"
 msgstr "le courriel n'a pas pu être envoyé à tous les destinataires"
 
-#: src/msmtp.c:4146 src/msmtp.c:4201 src/msmtp.c:4222
+#: src/msmtp.c:4304 src/msmtp.c:4359 src/msmtp.c:4380
 #, c-format
 msgid "server message: %s"
 msgstr "message du serveur : %s"
 
-#: src/msmtp.c:4152
+#: src/msmtp.c:4310
 #, c-format
 msgid "could not send mail (account %s from %s)"
 msgstr "le courriel n'a pas pu être envoyé (compte %s dans %s)"
 
-#: src/msmtp.c:4157
+#: src/msmtp.c:4315
 msgid "could not send mail"
 msgstr "le courriel n'a pas pu être envoyé"
 
-#: src/msmtp.c:4167
+#: src/msmtp.c:4325
 #, c-format
 msgid "delivery to one or more recipients failed"
 msgstr "l'envoi à un ou plusieurs destinataire a échoué"
@@ -1664,16 +1670,6 @@ msgstr "erreur de connexion à %s, port %d : %s"
 msgid "password for %s at %s: "
 msgstr "mot de passe pour %s à %s : "
 
-#: src/password.c:252
-#, c-format
-msgid "cannot evaluate '%s': %s"
-msgstr "impossible de résoudre \"%s\" : %s"
-
-#: src/password.c:262
-#, c-format
-msgid "cannot read output of '%s'"
-msgstr "impossible de lire la sortie de \"%s\""
-
 #: src/smtp.c:208
 #, c-format
 msgid "the server sent an empty reply"
@@ -1809,6 +1805,14 @@ msgstr "le serveur n'est pas en mesure de satisfaire la demande"
 #, c-format
 msgid "invalid argument for Remote Message Queue Starting"
 msgstr "argument invalide pour Remote Message Queue Starting"
+
+#, c-format
+#~ msgid "cannot evaluate '%s': %s"
+#~ msgstr "impossible de résoudre \"%s\" : %s"
+
+#, c-format
+#~ msgid "cannot read output of '%s'"
+#~ msgstr "impossible de lire la sortie de \"%s\""
 
 #~ msgid "Common Name"
 #~ msgstr "Nom Usuel"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: msmtp 1.8.14\n"
 "Report-Msgid-Bugs-To: marlam@marlam.de\n"
-"POT-Creation-Date: 2022-03-23 20:22+0100\n"
+"POT-Creation-Date: 2022-07-27 18:42+0200\n"
 "PO-Revision-Date: 2020-12-25 08:32-0300\n"
 "Last-Translator: Rafael Fontenelle <rafaelff@gnome.org>\n"
 "Language-Team: Brazilian Portuguese <ldpbr-translation@lists.sourceforge."
@@ -44,7 +44,7 @@ msgstr "linha %d: argumento inválido %s para o comando %s"
 msgid "line %d: duplicate alias '%s'"
 msgstr ""
 
-#: src/aliases.c:178 src/conf.c:1072 src/stream.c:63
+#: src/aliases.c:178 src/conf.c:1193 src/stream.c:63
 #, c-format
 msgid "input error"
 msgstr "erro de entrada"
@@ -54,32 +54,32 @@ msgstr "erro de entrada"
 msgid "Too many redirects when expanding alias %s."
 msgstr ""
 
-#: src/conf.c:808 src/conf.c:823
+#: src/conf.c:815 src/conf.c:830
 #, c-format
 msgid "host not set"
 msgstr "host não configurado"
 
-#: src/conf.c:813
+#: src/conf.c:820
 #, c-format
 msgid "port not set"
 msgstr "porta não configurada"
 
-#: src/conf.c:818
+#: src/conf.c:825
 #, c-format
 msgid "envelope-from address is missing"
 msgstr "falta o endereço envelope-from"
 
-#: src/conf.c:828
+#: src/conf.c:835
 #, c-format
 msgid "tls_key_file requires tls_cert_file"
 msgstr "tls_key_file requer tls_cert_file"
 
-#: src/conf.c:833
+#: src/conf.c:840
 #, c-format
 msgid "tls_cert_file requires tls_key_file"
 msgstr "tls_cert_file requer tls_key_file"
 
-#: src/conf.c:841
+#: src/conf.c:848
 #, c-format
 msgid ""
 "tls requires either tls_trust_file (highly recommended) or tls_fingerprint "
@@ -88,73 +88,73 @@ msgstr ""
 "tls requer tls_trust_file (altamente recomendado) ou tls_fingerprint ou um "
 "tls_certcheck desligado"
 
-#: src/conf.c:847
+#: src/conf.c:854
 #, c-format
 msgid "tls_crl_file requires tls_trust_file"
 msgstr "tls_crl_file requer tls_trust_file"
 
-#: src/conf.c:879 src/conf.c:886 src/conf.c:903 src/mtls-gnutls.c:328
+#: src/conf.c:886 src/conf.c:893 src/conf.c:910 src/mtls-gnutls.c:328
 #, c-format
 msgid "%s: %s"
 msgstr "%s: %s"
 
-#: src/conf.c:1094
-#, c-format
-msgid "line longer than %d characters"
-msgstr "linha maior do que %d caracteres"
-
-#: src/conf.c:1145 src/conf.c:1270
+#: src/conf.c:1119 src/conf.c:1292
 #, c-format
 msgid "line %d: missing account name"
 msgstr "linha %d: nome da conta inexistente"
 
-#: src/conf.c:1150
+#: src/conf.c:1124
 #, c-format
 msgid "line %d: account %s not (yet) defined"
 msgstr "linha %d: a conta %s (ainda) não foi definida"
 
-#: src/conf.c:1242 src/conf.c:2060 src/conf.c:2077
+#: src/conf.c:1205
 #, c-format
-msgid "line %d: command %s does not take an argument"
-msgstr "linha %d: o comando %s não aceita um argumento"
+msgid "line longer than %d characters"
+msgstr "linha maior do que %d caracteres"
 
-#: src/conf.c:1278
-#, c-format
-msgid "line %d: an account name must not contain colons or commas"
-msgstr "linha %d: um nome de conta não deve conter dois pontos ou vírgulas"
-
-#: src/conf.c:1288
-#, c-format
-msgid "line %d: account %s was already defined"
-msgstr "linha %d: a conta %s já foi definida"
-
-#: src/conf.c:1313 src/conf.c:1332 src/conf.c:1359 src/conf.c:1388
-#: src/conf.c:1695 src/conf.c:1730
+#: src/conf.c:1222 src/conf.c:1335 src/conf.c:1354 src/conf.c:1381
+#: src/conf.c:1410 src/conf.c:1718 src/conf.c:1753
 #, c-format
 msgid "line %d: command %s needs an argument"
 msgstr "linha %d: o comando %s necessita de um argumento"
 
-#: src/conf.c:1343 src/conf.c:1375 src/conf.c:1406 src/conf.c:1440
-#: src/conf.c:1466 src/conf.c:1511 src/conf.c:1531 src/conf.c:1616
-#: src/conf.c:1637 src/conf.c:1656 src/conf.c:1717 src/conf.c:1748
-#: src/conf.c:1798 src/conf.c:1845 src/conf.c:1870 src/conf.c:1890
-#: src/conf.c:1910 src/conf.c:1930 src/conf.c:1977 src/conf.c:1998
-#: src/conf.c:2019 src/conf.c:2047
+#: src/conf.c:1264 src/conf.c:2103 src/conf.c:2120
+#, c-format
+msgid "line %d: command %s does not take an argument"
+msgstr "linha %d: o comando %s não aceita um argumento"
+
+#: src/conf.c:1300
+#, c-format
+msgid "line %d: an account name must not contain colons or commas"
+msgstr "linha %d: um nome de conta não deve conter dois pontos ou vírgulas"
+
+#: src/conf.c:1310
+#, c-format
+msgid "line %d: account %s was already defined"
+msgstr "linha %d: a conta %s já foi definida"
+
+#: src/conf.c:1365 src/conf.c:1397 src/conf.c:1428 src/conf.c:1462
+#: src/conf.c:1488 src/conf.c:1534 src/conf.c:1554 src/conf.c:1639
+#: src/conf.c:1660 src/conf.c:1679 src/conf.c:1740 src/conf.c:1771
+#: src/conf.c:1821 src/conf.c:1868 src/conf.c:1893 src/conf.c:1913
+#: src/conf.c:1933 src/conf.c:1953 src/conf.c:1973 src/conf.c:2020
+#: src/conf.c:2041 src/conf.c:2062 src/conf.c:2090
 #, c-format
 msgid "line %d: invalid argument %s for command %s"
 msgstr "linha %d: argumento inválido %s para o comando %s"
 
-#: src/conf.c:2093
+#: src/conf.c:2136
 #, c-format
 msgid "line %d: unknown command %s"
 msgstr "linha %d: comando desconhecido %s"
 
-#: src/conf.c:2145
+#: src/conf.c:2190
 #, c-format
 msgid "contains secrets and therefore must be owned by you"
 msgstr "contém segredos e, portanto, deve pertencer a você"
 
-#: src/conf.c:2151
+#: src/conf.c:2196
 #, c-format
 msgid ""
 "contains secrets and therefore must have no more than user read/write "
@@ -165,215 +165,215 @@ msgstr ""
 
 #. TRANSLATORS: msmtp shares a lot of code and translatable strings with
 #. mpop <https://marlam.de/mpop>.
-#: src/msmtp.c:88
+#: src/msmtp.c:90
 #, c-format
 msgid "%s: FATAL: %s\n"
 msgstr "%s: FATAL: %s\n"
 
-#: src/msmtp.c:228 src/msmtp.c:406 src/msmtp.c:1401
+#: src/msmtp.c:230 src/msmtp.c:408 src/msmtp.c:1522
 #, c-format
 msgid "the server does not support TLS via the STARTTLS command"
 msgstr "o servidor não suporta TLS através do comando STARTTLS"
 
-#: src/msmtp.c:270
+#: src/msmtp.c:272
 #, c-format
 msgid "the server does not support Remote Message Queue Starting"
 msgstr "o servidor não suporta Remote Message Queue Starting"
 
-#: src/msmtp.c:282 src/msmtp.c:1459
+#: src/msmtp.c:284 src/msmtp.c:1580
 #, c-format
 msgid "the server does not support authentication"
 msgstr "o servidor não suporta autenticação"
 
-#: src/msmtp.c:441
+#: src/msmtp.c:443
 #, c-format
 msgid "%s server at %s (%s [%s]), port %d:\n"
 msgstr "%s servindo em %s (%s [%s]), porta %d:\n"
 
-#: src/msmtp.c:447
+#: src/msmtp.c:450
 #, c-format
 msgid "%s server at %s (%s), port %d:\n"
 msgstr "%s servindo em %s (%s), porta %d:\n"
 
-#: src/msmtp.c:453
+#: src/msmtp.c:457
 #, c-format
 msgid "%s server at %s ([%s]), port %d:\n"
 msgstr "%s servindo em %s ([%s]), porta %d:\n"
 
-#: src/msmtp.c:459
+#: src/msmtp.c:464
 #, c-format
 msgid "%s server at %s, port %d:\n"
 msgstr "%s servindo em %s, porta %d:\n"
 
-#: src/msmtp.c:479
+#: src/msmtp.c:485
 #, c-format
 msgid "No special capabilities.\n"
 msgstr "Sem capacidades especiais.\n"
 
-#: src/msmtp.c:483
+#: src/msmtp.c:489
 #, c-format
 msgid "Capabilities:\n"
 msgstr "Capacidades:\n"
 
-#: src/msmtp.c:487
+#: src/msmtp.c:493
 msgid "Maximum message size is "
 msgstr "O tamanho máximo da mensagem é "
 
-#: src/msmtp.c:490
+#: src/msmtp.c:496
 #, c-format
 msgid "unlimited\n"
 msgstr "ilimitado\n"
 
-#: src/msmtp.c:494
+#: src/msmtp.c:500
 #, c-format
 msgid "%ld bytes"
 msgstr "%ld bytes"
 
-#: src/msmtp.c:497
+#: src/msmtp.c:503
 #, c-format
 msgid " = %.2f MiB"
 msgstr " = %.2f MiB"
 
-#: src/msmtp.c:502
+#: src/msmtp.c:508
 #, c-format
 msgid " = %.2f KiB"
 msgstr " = %.2f KiB"
 
-#: src/msmtp.c:509
+#: src/msmtp.c:515
 msgid "Support for command grouping for faster transmission"
 msgstr "Suporte ao agrupamento de comandos para a transmissão mais rápida"
 
-#: src/msmtp.c:514
+#: src/msmtp.c:520
 msgid "Support for RMQS (Remote Message Queue Starting)"
 msgstr "Suporte a RMQS (Remote Message Queue Starting)"
 
-#: src/msmtp.c:519
+#: src/msmtp.c:525
 msgid "Support for Delivery Status Notifications"
 msgstr "Suporte a Delivery Status Notifications"
 
-#: src/msmtp.c:529
+#: src/msmtp.c:535
 msgid "Support for TLS encryption via the STARTTLS command"
 msgstr "Suporte a criptografia TLS através do comando STARTTLS"
 
-#: src/msmtp.c:535
+#: src/msmtp.c:541
 msgid "Supported authentication methods:"
 msgstr "Métodos de autenticação suportados:"
 
-#: src/msmtp.c:588
+#: src/msmtp.c:594
 #, c-format
 msgid ""
 "This server might advertise more or other capabilities when TLS is active.\n"
 msgstr ""
 "Este servidor pode anunciar outras capacidades quando o TLS estiver ativo.\n"
 
-#: src/msmtp.c:1153 src/msmtp.c:3299
+#: src/msmtp.c:1274 src/msmtp.c:3447
 #, c-format
 msgid "cannot write mail headers to temporary file: output error"
 msgstr ""
 "não foi possível escrever os cabeçalhos da mensagem no arquivo temporário: "
 "erro de saída"
 
-#: src/msmtp.c:1261
+#: src/msmtp.c:1382
 #, c-format
 msgid "input error while reading the mail"
 msgstr "erro de entrada ao ler a mensagem"
 
-#: src/msmtp.c:1448
+#: src/msmtp.c:1569
 #, c-format
 msgid "the server does not support DSN"
 msgstr "este servidor não suporta DSN"
 
-#: src/msmtp.c:1597 src/msmtp.c:1616 src/msmtp.c:1668
+#: src/msmtp.c:1718 src/msmtp.c:1737 src/msmtp.c:1789
 #, c-format
 msgid "automatic configuration based on SRV records failed: %s"
 msgstr "configuração automática baseada em servidores SRV falhou: %s"
 
-#: src/msmtp.c:1598
+#: src/msmtp.c:1719
 msgid "invalid mail address"
 msgstr "endereço de mensagem inválido"
 
-#: src/msmtp.c:1614
+#: src/msmtp.c:1735
 #, c-format
 msgid "no SRV records for %s or %s"
 msgstr "nenhum registro SRV para %s ou %s"
 
-#: src/msmtp.c:1631
+#: src/msmtp.c:1752
 #, c-format
 msgid "copy this to your configuration file %s"
 msgstr "copie isso para o seu arquivo de configuração %s"
 
-#: src/msmtp.c:1635
+#: src/msmtp.c:1756
 msgid "warning: the host does not match the mail domain; please check"
 msgstr ""
 "aviso: o host não corresponde ao domínio de e-mail; por favor, verifique isto"
 
-#: src/msmtp.c:1638 src/msmtp.c:1642
+#: src/msmtp.c:1759 src/msmtp.c:1763
 msgid "add your password to the key ring:"
 msgstr "adicione sua senha para o chaveiro:"
 
-#: src/msmtp.c:1645
+#: src/msmtp.c:1766
 msgid "encrypt your password:"
 msgstr "criptografe sua senha:"
 
-#: src/msmtp.c:1669
+#: src/msmtp.c:1790
 msgid "this system lacks libresolv"
 msgstr "esse sistema carece de libresolv"
 
-#: src/msmtp.c:1896
+#: src/msmtp.c:2022
 #, c-format
 msgid "invalid logfile_time_format"
 msgstr "logfile_time_format inválido"
 
-#: src/msmtp.c:1909
+#: src/msmtp.c:2035
 #, c-format
 msgid "cannot open: %s"
 msgstr "não foi possível abrir: %s"
 
-#: src/msmtp.c:1917
+#: src/msmtp.c:2043
 #, c-format
 msgid "cannot lock (tried for %d seconds): %s"
 msgstr "não foi possível travar (tentado por %d segundos): %s"
 
-#: src/msmtp.c:1922
+#: src/msmtp.c:2048
 #, c-format
 msgid "cannot lock: %s"
 msgstr "não foi possível travar: %s"
 
-#: src/msmtp.c:1931
+#: src/msmtp.c:2057
 msgid "output error"
 msgstr "erro de saída"
 
-#: src/msmtp.c:1948
+#: src/msmtp.c:2074
 #, c-format
 msgid "cannot log to %s: %s"
 msgstr "não foi possível registrar log em %s: %s"
 
-#: src/msmtp.c:1952
+#: src/msmtp.c:2078
 #, c-format
 msgid "log info was: %s"
 msgstr "as informações do log foram: %s"
 
-#: src/msmtp.c:2061
+#: src/msmtp.c:2187
 #, c-format
 msgid "%s version %s\n"
 msgstr "%s versão %s\n"
 
-#: src/msmtp.c:2062
+#: src/msmtp.c:2188
 #, c-format
 msgid "Platform: %s\n"
 msgstr "Plataforma: %s\n"
 
-#: src/msmtp.c:2064
+#: src/msmtp.c:2190
 #, c-format
 msgid "TLS/SSL library: %s\n"
 msgstr "Biblioteca TLS/SSL: %s\n"
 
-#: src/msmtp.c:2072 src/msmtp.c:2150
+#: src/msmtp.c:2198 src/msmtp.c:2276
 #, c-format
 msgid "none"
 msgstr "nenhum"
 
-#: src/msmtp.c:2076
+#: src/msmtp.c:2202
 #, c-format
 msgid ""
 "Authentication library: %s\n"
@@ -382,65 +382,65 @@ msgstr ""
 "Biblioteca de autenticação: %s\n"
 "Métodos de autenticação suportados:\n"
 
-#: src/msmtp.c:2079
+#: src/msmtp.c:2205
 msgid "GNU SASL; oauthbearer and xoauth2: built-in"
 msgstr "GNU SASL; oauthbearer and xoauth2: interno"
 
-#: src/msmtp.c:2081
+#: src/msmtp.c:2207
 msgid "built-in"
 msgstr "interno"
 
-#: src/msmtp.c:2130
+#: src/msmtp.c:2256
 #, c-format
 msgid "IDN support: "
 msgstr "Suporte a IDN: "
 
-#: src/msmtp.c:2134 src/msmtp.c:2142
+#: src/msmtp.c:2260 src/msmtp.c:2268
 #, c-format
 msgid "enabled"
 msgstr "habilitado"
 
-#: src/msmtp.c:2136 src/msmtp.c:2145
+#: src/msmtp.c:2262 src/msmtp.c:2271
 #, c-format
 msgid "disabled"
 msgstr "desabilitado"
 
-#: src/msmtp.c:2140
+#: src/msmtp.c:2266
 #, c-format
 msgid "NLS: "
 msgstr "NLS: "
 
-#: src/msmtp.c:2143
+#: src/msmtp.c:2269
 #, c-format
 msgid ", LOCALEDIR is %s"
 msgstr ", LOCALEDIR é %s"
 
-#: src/msmtp.c:2148
+#: src/msmtp.c:2274
 #, c-format
 msgid "Keyring support: "
 msgstr "Suporte a chaveiro: "
 
-#: src/msmtp.c:2153
+#: src/msmtp.c:2279
 #, c-format
 msgid "Gnome "
 msgstr "GNOME "
 
-#: src/msmtp.c:2156
+#: src/msmtp.c:2282
 #, c-format
 msgid "MacOS "
 msgstr "MacOS "
 
-#: src/msmtp.c:2162
+#: src/msmtp.c:2288
 #, c-format
 msgid "System configuration file name: %s\n"
 msgstr "Nome do arquivo de configuração do sistema: %s\n"
 
-#: src/msmtp.c:2166
+#: src/msmtp.c:2292
 #, c-format
 msgid "User configuration file name: %s\n"
 msgstr "Nome do arquivo de configuração do usuário: %s\n"
 
-#: src/msmtp.c:2169
+#: src/msmtp.c:2295
 #, fuzzy, c-format
 #| msgid ""
 #| "Copyright (C) 2020 Martin Lambers and others.\n"
@@ -462,7 +462,7 @@ msgstr ""
 "html>.\n"
 "Há NENHUMA GARANTIA, na extensão permitida pela lei.\n"
 
-#: src/msmtp.c:2186
+#: src/msmtp.c:2312
 #, c-format
 msgid ""
 "Usage:\n"
@@ -471,7 +471,7 @@ msgstr ""
 "Uso:\n"
 "\n"
 
-#: src/msmtp.c:2187
+#: src/msmtp.c:2313
 #, c-format
 msgid ""
 "Sendmail mode (default):\n"
@@ -486,7 +486,7 @@ msgstr ""
 "  Lê mensagem da entrada padrão e a transmite para um servidor SMTP ou "
 "LMTP.\n"
 
-#: src/msmtp.c:2192
+#: src/msmtp.c:2318
 #, c-format
 msgid ""
 "Configuration mode:\n"
@@ -497,7 +497,7 @@ msgstr ""
 "  %s --configure=endereço-mensagem\n"
 "  Gera e exibe a configuração para o endereço.\n"
 
-#: src/msmtp.c:2195
+#: src/msmtp.c:2321
 #, c-format
 msgid ""
 "Server information mode:\n"
@@ -508,7 +508,7 @@ msgstr ""
 "  %s [opção...] --serverinfo\n"
 "  Exibe informações sobre um servidor.\n"
 
-#: src/msmtp.c:2198
+#: src/msmtp.c:2324
 #, c-format
 msgid ""
 "Remote Message Queue Starting mode:\n"
@@ -521,49 +521,49 @@ msgstr ""
 "  Envia uma requisição Remote Message Queue Starting para um servidor.\n"
 "\n"
 
-#: src/msmtp.c:2202
+#: src/msmtp.c:2328
 #, c-format
 msgid "General options:\n"
 msgstr "Opções gerais:\n"
 
-#: src/msmtp.c:2203
+#: src/msmtp.c:2329
 #, c-format
 msgid "  --version                    print version\n"
 msgstr "  --version                    exibe a versão\n"
 
-#: src/msmtp.c:2204
+#: src/msmtp.c:2330
 #, c-format
 msgid "  --help                       print help\n"
 msgstr "  --help                       exibe essa ajuda\n"
 
-#: src/msmtp.c:2205
+#: src/msmtp.c:2331
 #, c-format
 msgid "  -P, --pretend                print configuration info and exit\n"
 msgstr "  -P, --pretend                exibe info das configurações e sai\n"
 
-#: src/msmtp.c:2206
+#: src/msmtp.c:2332
 #, c-format
 msgid "  -d, --debug                  print debugging information\n"
 msgstr "  -d, --debug                  exibe informações de depuração\n"
 
-#: src/msmtp.c:2207
+#: src/msmtp.c:2333
 #, c-format
 msgid "Changing the mode of operation:\n"
 msgstr "Alterando o modo de operação:\n"
 
-#: src/msmtp.c:2208
+#: src/msmtp.c:2334
 #, c-format
 msgid ""
 "  --configure=mailaddress      generate and print configuration for address\n"
 msgstr ""
 "  --configure=e-mail           gera e exibe a configuração para o endereço\n"
 
-#: src/msmtp.c:2209
+#: src/msmtp.c:2335
 #, c-format
 msgid "  -S, --serverinfo             print information about the server\n"
 msgstr "  -S, --serverinfo             exibe informações sobre o servidor\n"
 
-#: src/msmtp.c:2210
+#: src/msmtp.c:2336
 #, c-format
 msgid ""
 "  --rmqs=host|@domain|#queue   send a Remote Message Queue Starting request\n"
@@ -571,17 +571,17 @@ msgstr ""
 "  --rmqs=host|@domínio|#fila   envia requisição de Remote Message Queue "
 "Starting\n"
 
-#: src/msmtp.c:2211
+#: src/msmtp.c:2337
 #, c-format
 msgid "Configuration options:\n"
 msgstr "Opções de configuração:\n"
 
-#: src/msmtp.c:2212
+#: src/msmtp.c:2338
 #, c-format
 msgid "  -C, --file=filename          set configuration file\n"
 msgstr "  -C, --file=arquivo           define o arquivo de configuração\n"
 
-#: src/msmtp.c:2213
+#: src/msmtp.c:2339
 #, c-format
 msgid ""
 "  -a, --account=id             use the given account instead of the account\n"
@@ -594,7 +594,7 @@ msgstr ""
 "                                 \"default\"; suas configurações podem ser\n"
 "                                 alteradas com opções de linha de comando\n"
 
-#: src/msmtp.c:2216
+#: src/msmtp.c:2342
 #, c-format
 msgid ""
 "  --host=hostname              set the server, use only command-line "
@@ -607,12 +607,12 @@ msgstr ""
 "arquivo\n"
 "                                 de configuração\n"
 
-#: src/msmtp.c:2218
+#: src/msmtp.c:2344
 #, c-format
 msgid "  --port=number                set port number\n"
 msgstr "  --port=número                define o número da porta\n"
 
-#: src/msmtp.c:2219
+#: src/msmtp.c:2345
 #, c-format
 msgid ""
 "  --source-ip=[IP]             set/unset source ip address to bind the "
@@ -621,44 +621,44 @@ msgstr ""
 "  --source-ip=[IP]             define/remove definição de endereço IP fonte\n"
 "                                 a ser vinculado a soquetes\n"
 
-#: src/msmtp.c:2220
+#: src/msmtp.c:2346
 #, c-format
 msgid "  --proxy-host=[IP|hostname]   set/unset proxy\n"
 msgstr "  --proxy-host=[IP|hostname]   define/remove definição de proxy\n"
 
-#: src/msmtp.c:2221
+#: src/msmtp.c:2347
 #, c-format
 msgid "  --proxy-port=[number]        set/unset proxy port\n"
 msgstr ""
 "  --proxy-port=[número]        define/remove definição da porta do proxy\n"
 
-#: src/msmtp.c:2222
+#: src/msmtp.c:2348
 #, c-format
 msgid "  --socket=[socketname]        set/unset local socket to connect to\n"
 msgstr ""
 "  --socket=[nome-soquete]      define/remove definição de soquete\n"
 "                                 para conectar\n"
 
-#: src/msmtp.c:2223
+#: src/msmtp.c:2349
 #, c-format
 msgid "  --timeout=(off|seconds)      set/unset network timeout in seconds\n"
 msgstr ""
 "  --timeout=(off|segundos)     define/remove definição de tempo limite\n"
 "                                 de rede em segundos\n"
 
-#: src/msmtp.c:2224
+#: src/msmtp.c:2350
 #, c-format
 msgid "  --protocol=(smtp|lmtp)       use the given sub protocol\n"
 msgstr "  --protocol=(smtp|lmtp)       usa o subprotocolo fornecido\n"
 
-#: src/msmtp.c:2225
+#: src/msmtp.c:2351
 #, c-format
 msgid ""
 "  --domain=string              set the argument of EHLO or LHLO command\n"
 msgstr ""
 "  --domain=texto               define o argumento do comando EHLO ou LHLO\n"
 
-#: src/msmtp.c:2226
+#: src/msmtp.c:2352
 #, c-format
 msgid ""
 "  --auth[=(on|off|method)]     enable/disable authentication and optionally\n"
@@ -667,29 +667,29 @@ msgstr ""
 "  --auth[=(on|off|método)]     habilita/desabilita autenticação e,\n"
 "                                 opcionalmente, escolhe um método\n"
 
-#: src/msmtp.c:2228
+#: src/msmtp.c:2354
 #, c-format
 msgid "  --user=[username]            set/unset user name for authentication\n"
 msgstr ""
 "  --user=[usuário]             define/remove definição de nome de usuário\n"
 "                                 para autenticação\n"
 
-#: src/msmtp.c:2229
+#: src/msmtp.c:2355
 #, c-format
 msgid "  --passwordeval=[eval]        evaluate password for authentication\n"
 msgstr "  --passwordeval=[eval]        avalia a senha para autenticação\n"
 
-#: src/msmtp.c:2230
+#: src/msmtp.c:2356
 #, c-format
 msgid "  --tls[=(on|off)]             enable/disable TLS encryption\n"
 msgstr "  --tls[=(on|off)]             habilita/desabilita criptografia TLS\n"
 
-#: src/msmtp.c:2231
+#: src/msmtp.c:2357
 #, c-format
 msgid "  --tls-starttls[=(on|off)]    enable/disable STARTTLS for TLS\n"
 msgstr "  --tls-starttls[=(on|off)]    habilita/desabilita STARTTLS para TLS\n"
 
-#: src/msmtp.c:2232
+#: src/msmtp.c:2358
 #, c-format
 msgid "  --tls-trust-file=[file]      set/unset trust file for TLS\n"
 msgstr ""
@@ -697,7 +697,7 @@ msgstr ""
 "confiança\n"
 "                                 para TLS\n"
 
-#: src/msmtp.c:2233
+#: src/msmtp.c:2359
 #, c-format
 msgid "  --tls-crl-file=[file]        set/unset revocation file for TLS\n"
 msgstr ""
@@ -705,7 +705,7 @@ msgstr ""
 "revogação\n"
 "                                 para TLS\n"
 
-#: src/msmtp.c:2234
+#: src/msmtp.c:2360
 #, c-format
 msgid ""
 "  --tls-fingerprint=[f]        set/unset trusted certificate fingerprint for "
@@ -715,7 +715,7 @@ msgstr ""
 "definição\n"
 "                                 de certificado confiado para TLS\n"
 
-#: src/msmtp.c:2235
+#: src/msmtp.c:2361
 #, c-format
 msgid ""
 "  --tls-certcheck[=(on|off)]   enable/disable server certificate checks for "
@@ -725,28 +725,28 @@ msgstr ""
 "certificado\n"
 "                                 do servidor para TLS\n"
 
-#: src/msmtp.c:2236
+#: src/msmtp.c:2362
 #, c-format
 msgid "  --tls-key-file=[file]        set/unset private key file for TLS\n"
 msgstr ""
 "  --tls-key-file=[arquivo]     define/remove definição de arquivo de chave\n"
 "                                 privada para TLS\n"
 
-#: src/msmtp.c:2237
+#: src/msmtp.c:2363
 #, c-format
 msgid "  --tls-cert-file=[file]       set/unset private cert file for TLS\n"
 msgstr ""
 "  --tls-cert-file=[arquivo]    define/remove definição de arquivo de\n"
 "                                 certificado privado para TLS\n"
 
-#: src/msmtp.c:2238
+#: src/msmtp.c:2364
 #, c-format
 msgid "  --tls-priorities=[prios]     set/unset TLS priorities.\n"
 msgstr ""
 "  --tls-priorities=[prio]      define/remove definição de prioridades de "
 "TLS.\n"
 
-#: src/msmtp.c:2239
+#: src/msmtp.c:2365
 #, c-format
 msgid ""
 "  --tls-host-override=[host]   set/unset override for TLS host "
@@ -756,19 +756,19 @@ msgstr ""
 "de\n"
 "                                 host TLS.\n"
 
-#: src/msmtp.c:2240
+#: src/msmtp.c:2366
 #, c-format
 msgid "  --tls-min-dh-prime-bits=[b]  set/unset minimum bit size of DH prime\n"
 msgstr ""
 "  --tls-min-dh-prime-bits=[b]  define/remove definição de tamanho mínimo de\n"
 "                                 bit de primo de DH\n"
 
-#: src/msmtp.c:2241
+#: src/msmtp.c:2367
 #, c-format
 msgid "Options specific to sendmail mode:\n"
 msgstr "Opções específicas para o modo sendmail:\n"
 
-#: src/msmtp.c:2242
+#: src/msmtp.c:2368
 #, c-format
 msgid ""
 "  --auto-from[=(on|off)]       enable/disable automatic envelope-from "
@@ -778,12 +778,12 @@ msgstr ""
 "from\n"
 "                                 automáticos\n"
 
-#: src/msmtp.c:2243
+#: src/msmtp.c:2369
 #, c-format
 msgid "  -f, --from=address           set envelope from address\n"
 msgstr "  -f, --from=endereço          define um endereço de envelope from\n"
 
-#: src/msmtp.c:2244
+#: src/msmtp.c:2370
 #, c-format
 msgid ""
 "  --maildomain=[domain]        set the domain for automatic envelope from\n"
@@ -792,25 +792,25 @@ msgstr ""
 "  --maildomain=[domínio]       define o domínio para endereços de envelope\n"
 "                                 from automáticos\n"
 
-#: src/msmtp.c:2246
+#: src/msmtp.c:2372
 #, c-format
 msgid "  -N, --dsn-notify=(off|cond)  set/unset DSN conditions\n"
 msgstr ""
 "  -N, --dsn-notify=(off|cond)  define/remove definição de condições DSN\n"
 
-#: src/msmtp.c:2247
+#: src/msmtp.c:2373
 #, c-format
 msgid "  -R, --dsn-return=(off|ret)   set/unset DSN amount\n"
 msgstr ""
 "  -R, --dsn-return=(off|ret)   define/remove definição de quantidade DSN\n"
 
-#: src/msmtp.c:2248
+#: src/msmtp.c:2374
 #, c-format
 msgid "  -X, --logfile=[file]         set/unset log file\n"
 msgstr ""
 "  -X, --logfile=[arquivo]      define/remove definição de arquivo de log\n"
 
-#: src/msmtp.c:2249
+#: src/msmtp.c:2375
 #, c-format
 msgid ""
 "  --logfile-time-format=[fmt]  set/unset log file time format for "
@@ -820,47 +820,54 @@ msgstr ""
 "do\n"
 "                                 arquivo de log para strftime()\n"
 
-#: src/msmtp.c:2250
+#: src/msmtp.c:2376
 #, c-format
 msgid ""
 "  --syslog[=(on|off|facility)] enable/disable/configure syslog logging\n"
 msgstr ""
 "  --syslog[=(on|off|facility)] habilita/desabilita/configura log com syslog\n"
 
-#: src/msmtp.c:2251
+#: src/msmtp.c:2377
 #, c-format
 msgid ""
 "  -t, --read-recipients        read additional recipients from the mail\n"
 msgstr ""
 "  -t, --read-recipients        lê destinatários adicionais da mensagem\n"
 
-#: src/msmtp.c:2252
+#: src/msmtp.c:2378
 #, c-format
 msgid ""
 "  --read-envelope-from         read envelope from address from the mail\n"
 msgstr ""
 "  --read-envelope-from         lê endereços de envelope from da mensagem\n"
 
-#: src/msmtp.c:2253
+#: src/msmtp.c:2379
 #, c-format
 msgid "  --aliases=[file]             set/unset aliases file\n"
 msgstr ""
 "  --aliases=[arquivo]          define/remove definição de arquivo de "
 "aliases\n"
 
-#: src/msmtp.c:2254
+#: src/msmtp.c:2380
 #, c-format
 msgid "  --set-from-header[=(auto|on|off)] set From header handling\n"
 msgstr ""
 "  --set-from-header[=(auto|on|off)] define a manipulação do cabeçalho From\n"
 
-#: src/msmtp.c:2255
+#: src/msmtp.c:2381
 #, c-format
 msgid "  --set-date-header[=(auto|off)] set Date header handling\n"
 msgstr ""
 "  --set-date-header[=(auto|off)] define a manipulação do cabeçalho Date\n"
 
-#: src/msmtp.c:2256
+#: src/msmtp.c:2382
+#, fuzzy, c-format
+#| msgid "  --set-date-header[=(auto|off)] set Date header handling\n"
+msgid "  --set-msgid-header[=(auto|off)] set Message-ID header handling\n"
+msgstr ""
+"  --set-date-header[=(auto|off)] define a manipulação do cabeçalho Date\n"
+
+#: src/msmtp.c:2383
 #, c-format
 msgid ""
 "  --remove-bcc-headers[=(on|off)] enable/disable removal of Bcc headers\n"
@@ -868,7 +875,7 @@ msgstr ""
 "  --remove-bcc-headers[=(on|off)] habilita/desabilita remoção de cabeçalhos "
 "Cco\n"
 
-#: src/msmtp.c:2257
+#: src/msmtp.c:2384
 #, c-format
 msgid ""
 "  --undisclosed-recipients[=(on|off)] enable/disable replacement of To/Cc/"
@@ -879,19 +886,19 @@ msgstr ""
 "                               Para/Cc/Cco com Para: undisclosed-"
 "recipients:;\n"
 
-#: src/msmtp.c:2259
+#: src/msmtp.c:2386
 #, c-format
 msgid "  --                           end of options\n"
 msgstr "  --                           fima das opções\n"
 
-#: src/msmtp.c:2260
+#: src/msmtp.c:2387
 #, c-format
 msgid ""
 "Accepted but ignored: -A, -B, -bm, -F, -G, -h, -i, -L, -m, -n, -O, -o, -v\n"
 msgstr ""
 "Aceitos, mas ignorados: -A, -B, -bm, -F, -G, -h, -i, -L, -m, -n, -O, -o, -v\n"
 
-#: src/msmtp.c:2261
+#: src/msmtp.c:2388
 #, c-format
 msgid ""
 "\n"
@@ -902,237 +909,237 @@ msgstr ""
 "Relate erros de tradução para <https://translationproject.org/team/pt_BR."
 "html>\n"
 
-#: src/msmtp.c:2503 src/msmtp.c:2517
+#: src/msmtp.c:2633 src/msmtp.c:2647
 msgid "cannot use both --serverinfo and --rmqs"
 msgstr "não é possível usar --serverinfo com --rmqs"
 
-#: src/msmtp.c:2537 src/msmtp.c:2549
+#: src/msmtp.c:2667 src/msmtp.c:2679
 msgid "cannot use both --host and --account"
 msgstr "não é possível usar --host com --account"
 
-#: src/msmtp.c:2565 src/msmtp.c:2583 src/msmtp.c:2602 src/msmtp.c:2657
-#: src/msmtp.c:2689 src/msmtp.c:2707 src/msmtp.c:2770 src/msmtp.c:2815
-#: src/msmtp.c:2837 src/msmtp.c:2883 src/msmtp.c:2908 src/msmtp.c:2927
-#: src/msmtp.c:2980 src/msmtp.c:3025 src/msmtp.c:3052 src/msmtp.c:3070
-#: src/msmtp.c:3089 src/msmtp.c:3108 src/msmtp.c:3126 src/msmtp.c:3144
-#: src/msmtp.c:3221
+#: src/msmtp.c:2695 src/msmtp.c:2713 src/msmtp.c:2732 src/msmtp.c:2787
+#: src/msmtp.c:2819 src/msmtp.c:2837 src/msmtp.c:2900 src/msmtp.c:2945
+#: src/msmtp.c:2967 src/msmtp.c:3013 src/msmtp.c:3038 src/msmtp.c:3057
+#: src/msmtp.c:3110 src/msmtp.c:3155 src/msmtp.c:3182 src/msmtp.c:3200
+#: src/msmtp.c:3218 src/msmtp.c:3237 src/msmtp.c:3256 src/msmtp.c:3274
+#: src/msmtp.c:3292 src/msmtp.c:3369
 #, c-format
 msgid "invalid argument %s for %s"
 msgstr "argumento inválido %s para %s"
 
-#: src/msmtp.c:2612 src/msmtp.c:3184
+#: src/msmtp.c:2742 src/msmtp.c:3332
 msgid "cannot use both --from and --read-envelope-from"
 msgstr "não é possível usar --from com --read-envelope-from"
 
-#: src/msmtp.c:3199
+#: src/msmtp.c:3347
 #, c-format
 msgid "unsupported operation mode b%s"
 msgstr "modo de operação sem suporte b%s"
 
-#: src/msmtp.c:3276 src/msmtp.c:3753 src/msmtp.c:4052
+#: src/msmtp.c:3424 src/msmtp.c:3904 src/msmtp.c:4204
 #, c-format
 msgid "cannot create temporary file: %s"
 msgstr "não foi possível criar o arquivo temporário: %s"
 
-#: src/msmtp.c:3306 src/msmtp.c:3778 src/msmtp.c:4085
+#: src/msmtp.c:3454 src/msmtp.c:3930 src/msmtp.c:4243
 #, c-format
 msgid "cannot rewind temporary file: %s"
 msgstr "não foi possível rebobinar o arquivo temporário: %s"
 
-#: src/msmtp.c:3371
+#: src/msmtp.c:3520
 #, c-format
 msgid "ignoring system configuration file %s: %s\n"
 msgstr "ignorando o arquivo de configuração do sistema %s: %s\n"
 
-#: src/msmtp.c:3386
+#: src/msmtp.c:3535
 #, c-format
 msgid "loaded system configuration file %s\n"
 msgstr "carregado o arquivo de configuração do sistema %s\n"
 
-#: src/msmtp.c:3425
+#: src/msmtp.c:3574
 #, c-format
 msgid "ignoring user configuration file %s: %s\n"
 msgstr "ignorando o arquivo de configuração do usuário %s: %s\n"
 
-#: src/msmtp.c:3440
+#: src/msmtp.c:3589
 #, c-format
 msgid "loaded user configuration file %s\n"
 msgstr "carregado o arquivo de configuração do usuário %s\n"
 
-#: src/msmtp.c:3497
+#: src/msmtp.c:3646
 #, c-format
 msgid "using account %s from %s\n"
 msgstr "usando a conta %s de %s\n"
 
-#: src/msmtp.c:3503 src/msmtp.c:3505 src/msmtp.c:3508 src/msmtp.c:3542
-#: src/msmtp.c:3543 src/msmtp.c:3545 src/msmtp.c:3547 src/msmtp.c:3551
-#: src/msmtp.c:3553 src/msmtp.c:3572 src/msmtp.c:3574 src/msmtp.c:3576
-#: src/msmtp.c:3586 src/msmtp.c:3589 src/msmtp.c:3591 src/msmtp.c:3596
-#: src/msmtp.c:3599 src/msmtp.c:3611 src/msmtp.c:3613 src/msmtp.c:3615
-#: src/msmtp.c:3618 src/msmtp.c:3620 src/msmtp.c:3622
+#: src/msmtp.c:3650 src/msmtp.c:3653 src/msmtp.c:3655 src/msmtp.c:3658
+#: src/msmtp.c:3692 src/msmtp.c:3693 src/msmtp.c:3695 src/msmtp.c:3697
+#: src/msmtp.c:3701 src/msmtp.c:3703 src/msmtp.c:3722 src/msmtp.c:3724
+#: src/msmtp.c:3726 src/msmtp.c:3736 src/msmtp.c:3739 src/msmtp.c:3741
+#: src/msmtp.c:3746 src/msmtp.c:3749 src/msmtp.c:3761 src/msmtp.c:3763
+#: src/msmtp.c:3765 src/msmtp.c:3768 src/msmtp.c:3770 src/msmtp.c:3772
 msgid "(not set)"
 msgstr "(não definido)"
 
-#: src/msmtp.c:3512
+#: src/msmtp.c:3662
 #, c-format
 msgid "off\n"
 msgstr "desligado\n"
 
-#: src/msmtp.c:3518
+#: src/msmtp.c:3668
 #, c-format
 msgid "%d seconds\n"
 msgstr "%d segundos\n"
 
-#: src/msmtp.c:3522
+#: src/msmtp.c:3672
 #, c-format
 msgid "1 second\n"
 msgstr "1 segundo\n"
 
-#: src/msmtp.c:3531
+#: src/msmtp.c:3681
 #, c-format
 msgid "none\n"
 msgstr "nenhum\n"
 
-#: src/msmtp.c:3535
+#: src/msmtp.c:3685
 #, c-format
 msgid "choose\n"
 msgstr "escolha\n"
 
-#: src/msmtp.c:3548 src/msmtp.c:3549 src/msmtp.c:3578 src/msmtp.c:3594
-#: src/msmtp.c:3602 src/msmtp.c:3607 src/msmtp.c:3609
+#: src/msmtp.c:3698 src/msmtp.c:3699 src/msmtp.c:3728 src/msmtp.c:3744
+#: src/msmtp.c:3752 src/msmtp.c:3757 src/msmtp.c:3759
 msgid "on"
 msgstr "ligado"
 
-#: src/msmtp.c:3548 src/msmtp.c:3549 src/msmtp.c:3578 src/msmtp.c:3594
-#: src/msmtp.c:3602 src/msmtp.c:3605 src/msmtp.c:3607 src/msmtp.c:3609
+#: src/msmtp.c:3698 src/msmtp.c:3699 src/msmtp.c:3728 src/msmtp.c:3744
+#: src/msmtp.c:3752 src/msmtp.c:3755 src/msmtp.c:3757 src/msmtp.c:3759
 msgid "off"
 msgstr "desligado"
 
-#: src/msmtp.c:3599
+#: src/msmtp.c:3749
 msgid "(read from mail)"
 msgstr "(lendo da mensagem)"
 
-#: src/msmtp.c:3601 src/msmtp.c:3604
+#: src/msmtp.c:3751 src/msmtp.c:3754
 msgid "auto"
 msgstr "auto"
 
-#: src/msmtp.c:3625
+#: src/msmtp.c:3775
 #, c-format
 msgid "reading recipients from the command line and the mail\n"
 msgstr "lendo destinatários da linha de comando e da mensagem\n"
 
-#: src/msmtp.c:3630
+#: src/msmtp.c:3780
 #, c-format
 msgid "reading recipients from the command line\n"
 msgstr "lendo destinatários da linha de comando\n"
 
-#: src/msmtp.c:3743
+#: src/msmtp.c:3894
 msgid "too many arguments"
 msgstr "excesso de argumentos"
 
-#: src/msmtp.c:3772
+#: src/msmtp.c:3924
 #, c-format
 msgid "envelope from address extracted from mail: %s\n"
 msgstr "endereço de envelope from extraído da mensagem: %s\n"
 
-#: src/msmtp.c:3787
+#: src/msmtp.c:3939
 msgid "no recipients found"
 msgstr "nenhum destinatário encontrado"
 
-#: src/msmtp.c:3817
+#: src/msmtp.c:3969
 #, c-format
 msgid "account chosen by envelope from address %s: %s\n"
 msgstr "conta escolhida pelo endereço de envelope from %s: %s\n"
 
-#: src/msmtp.c:3831
+#: src/msmtp.c:3983
 #, c-format
 msgid "falling back to default account\n"
 msgstr "retrocedendo para conta padrão\n"
 
-#: src/msmtp.c:3854
+#: src/msmtp.c:4006
 #, c-format
 msgid "using environment variables EMAIL and SMTPSERVER\n"
 msgstr "usando as variáveis de ambiente EMAIL e SMTPSERVER\n"
 
-#: src/msmtp.c:3862
+#: src/msmtp.c:4014
 #, c-format
 msgid "account %s not found in %s and %s"
 msgstr "conta %s não encontrada em %s e %s"
 
-#: src/msmtp.c:3868 src/msmtp.c:3873
+#: src/msmtp.c:4020 src/msmtp.c:4025
 #, c-format
 msgid "account %s not found in %s"
 msgstr "conta %s não encontrada em %s"
 
-#: src/msmtp.c:3878
+#: src/msmtp.c:4030
 #, c-format
 msgid "account %s not found: no configuration file available"
 msgstr "conta %s não encontrada: nenhum arquivo de configuração disponível"
 
-#: src/msmtp.c:3893
+#: src/msmtp.c:4045
 #, c-format
 msgid "using account specified on command line\n"
 msgstr "usando conta especificada na linha de comando\n"
 
-#: src/msmtp.c:3959
+#: src/msmtp.c:4110
 #, c-format
 msgid "account %s from %s: %s"
 msgstr "conta %s de %s: %s"
 
-#: src/msmtp.c:4000
+#: src/msmtp.c:4151
 msgid "this platform does not support syslog logging"
 msgstr "esta plataforma não tem suporte a registrar log via syslog"
 
-#: src/msmtp.c:4009
+#: src/msmtp.c:4160
 #, c-format
 msgid "support for authentication method %s is not compiled in"
 msgstr "o suporte ao método de autenticação %s não está compilado"
 
-#: src/msmtp.c:4017
+#: src/msmtp.c:4168
 #, c-format
 msgid "cannot initialize networking: %s"
 msgstr "não foi possível iniciar a rede: %s"
 
-#: src/msmtp.c:4028
+#: src/msmtp.c:4179
 #, c-format
 msgid "cannot initialize TLS library: %s"
 msgstr "não foi possível iniciar a biblioteca TLS: %s"
 
-#: src/msmtp.c:4035
+#: src/msmtp.c:4186
 msgid "support for TLS is not compiled in"
 msgstr "o suporte a TLS não está compilado"
 
-#: src/msmtp.c:4114
+#: src/msmtp.c:4272
 #, c-format
 msgid "LMTP server message: %s"
 msgstr "mensagem do servidor LMTP: %s"
 
-#: src/msmtp.c:4125
+#: src/msmtp.c:4283
 #, c-format
 msgid "could not send mail to all recipients (account %s from %s)"
 msgstr ""
 "não foi possível enviar a mensagem para todos os destinatários (conta %s de "
 "%s)"
 
-#: src/msmtp.c:4131
+#: src/msmtp.c:4289
 msgid "could not send mail to all recipients"
 msgstr "não foi possível enviar a mensagem para todos os destinatários"
 
-#: src/msmtp.c:4146 src/msmtp.c:4201 src/msmtp.c:4222
+#: src/msmtp.c:4304 src/msmtp.c:4359 src/msmtp.c:4380
 #, c-format
 msgid "server message: %s"
 msgstr "mensagem do servidor: %s"
 
-#: src/msmtp.c:4152
+#: src/msmtp.c:4310
 #, c-format
 msgid "could not send mail (account %s from %s)"
 msgstr "não foi possível enviar a mensagem (conta %s de %s)"
 
-#: src/msmtp.c:4157
+#: src/msmtp.c:4315
 msgid "could not send mail"
 msgstr "não foi possível enviar a mensagem"
 
-#: src/msmtp.c:4167
+#: src/msmtp.c:4325
 #, c-format
 msgid "delivery to one or more recipients failed"
 msgstr "a entrega para um ou mais destinatários falhou"
@@ -1669,16 +1676,6 @@ msgstr "não foi possível conectar em %s, porta %d: %s"
 msgid "password for %s at %s: "
 msgstr "senha para %s em %s: "
 
-#: src/password.c:252
-#, c-format
-msgid "cannot evaluate '%s': %s"
-msgstr "não foi possível avaliar \"%s\": %s"
-
-#: src/password.c:262
-#, c-format
-msgid "cannot read output of '%s'"
-msgstr "não foi possível ler a saída de \"%s\""
-
 #: src/smtp.c:208
 #, c-format
 msgid "the server sent an empty reply"
@@ -1813,6 +1810,14 @@ msgstr "o servidor não consegue completar a requisição"
 #, c-format
 msgid "invalid argument for Remote Message Queue Starting"
 msgstr "argumento inválido para Remote Message Queue Starting"
+
+#, c-format
+#~ msgid "cannot evaluate '%s': %s"
+#~ msgstr "não foi possível avaliar \"%s\": %s"
+
+#, c-format
+#~ msgid "cannot read output of '%s'"
+#~ msgstr "não foi possível ler a saída de \"%s\""
 
 #~ msgid "Common Name"
 #~ msgstr "Nome comum"

--- a/po/sr.po
+++ b/po/sr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: msmtp 1.8.18\n"
 "Report-Msgid-Bugs-To: marlam@marlam.de\n"
-"POT-Creation-Date: 2022-03-23 20:22+0100\n"
+"POT-Creation-Date: 2022-07-27 18:42+0200\n"
 "PO-Revision-Date: 2021-12-11 19:29+0200\n"
 "Last-Translator: Мирослав Николић <miroslavnikolic@rocketmail.com>\n"
 "Language-Team: Serbian <(nothing)>\n"
@@ -38,7 +38,7 @@ msgstr "%d. ред: неисправан алијас „%s“"
 msgid "line %d: duplicate alias '%s'"
 msgstr "%d. ред: двоструки алијас „%s“"
 
-#: src/aliases.c:178 src/conf.c:1072 src/stream.c:63
+#: src/aliases.c:178 src/conf.c:1193 src/stream.c:63
 #, c-format
 msgid "input error"
 msgstr "улазна грешка"
@@ -48,32 +48,32 @@ msgstr "улазна грешка"
 msgid "Too many redirects when expanding alias %s."
 msgstr "Превише преусмеравања приликом ширења алијаса „%s“."
 
-#: src/conf.c:808 src/conf.c:823
+#: src/conf.c:815 src/conf.c:830
 #, c-format
 msgid "host not set"
 msgstr "домаћин није подешен"
 
-#: src/conf.c:813
+#: src/conf.c:820
 #, c-format
 msgid "port not set"
 msgstr "прикључник није подешен"
 
-#: src/conf.c:818
+#: src/conf.c:825
 #, c-format
 msgid "envelope-from address is missing"
 msgstr "недостаје адреса за „коверту шаље“"
 
-#: src/conf.c:828
+#: src/conf.c:835
 #, c-format
 msgid "tls_key_file requires tls_cert_file"
 msgstr "„tls_key_file“ захтева „tls_cert_file“"
 
-#: src/conf.c:833
+#: src/conf.c:840
 #, c-format
 msgid "tls_cert_file requires tls_key_file"
 msgstr "„tls_cert_file“ захтева „tls_key_file“"
 
-#: src/conf.c:841
+#: src/conf.c:848
 #, c-format
 msgid ""
 "tls requires either tls_trust_file (highly recommended) or tls_fingerprint "
@@ -82,73 +82,73 @@ msgstr ""
 "тлс захтева или „tls_trust_file“ (веома препоручљиво) или „tls_fingerprint“ "
 "или искључено „tls_certcheck“"
 
-#: src/conf.c:847
+#: src/conf.c:854
 #, c-format
 msgid "tls_crl_file requires tls_trust_file"
 msgstr "„tls_crl_file“ захтева „tls_trust_file“"
 
-#: src/conf.c:879 src/conf.c:886 src/conf.c:903 src/mtls-gnutls.c:328
+#: src/conf.c:886 src/conf.c:893 src/conf.c:910 src/mtls-gnutls.c:328
 #, c-format
 msgid "%s: %s"
 msgstr "%s: %s"
 
-#: src/conf.c:1094
-#, c-format
-msgid "line longer than %d characters"
-msgstr "ред је дужи од %d знака"
-
-#: src/conf.c:1145 src/conf.c:1270
+#: src/conf.c:1119 src/conf.c:1292
 #, c-format
 msgid "line %d: missing account name"
 msgstr "%d. ред: недостаје назив налога"
 
-#: src/conf.c:1150
+#: src/conf.c:1124
 #, c-format
 msgid "line %d: account %s not (yet) defined"
 msgstr "%d. ред: налог „%s“ није (још увек) дефинисан"
 
-#: src/conf.c:1242 src/conf.c:2060 src/conf.c:2077
+#: src/conf.c:1205
 #, c-format
-msgid "line %d: command %s does not take an argument"
-msgstr "%d. ред: наредба „%s“ не захтева аргумент"
+msgid "line longer than %d characters"
+msgstr "ред је дужи од %d знака"
 
-#: src/conf.c:1278
-#, c-format
-msgid "line %d: an account name must not contain colons or commas"
-msgstr "%d. ред: назив налога не сме да садржи двотачке или зарезе"
-
-#: src/conf.c:1288
-#, c-format
-msgid "line %d: account %s was already defined"
-msgstr "%d. ред: налог „%s“ је већ дефинисан"
-
-#: src/conf.c:1313 src/conf.c:1332 src/conf.c:1359 src/conf.c:1388
-#: src/conf.c:1695 src/conf.c:1730
+#: src/conf.c:1222 src/conf.c:1335 src/conf.c:1354 src/conf.c:1381
+#: src/conf.c:1410 src/conf.c:1718 src/conf.c:1753
 #, c-format
 msgid "line %d: command %s needs an argument"
 msgstr "%d. ред: наредба „%s“ захтева аргумент"
 
-#: src/conf.c:1343 src/conf.c:1375 src/conf.c:1406 src/conf.c:1440
-#: src/conf.c:1466 src/conf.c:1511 src/conf.c:1531 src/conf.c:1616
-#: src/conf.c:1637 src/conf.c:1656 src/conf.c:1717 src/conf.c:1748
-#: src/conf.c:1798 src/conf.c:1845 src/conf.c:1870 src/conf.c:1890
-#: src/conf.c:1910 src/conf.c:1930 src/conf.c:1977 src/conf.c:1998
-#: src/conf.c:2019 src/conf.c:2047
+#: src/conf.c:1264 src/conf.c:2103 src/conf.c:2120
+#, c-format
+msgid "line %d: command %s does not take an argument"
+msgstr "%d. ред: наредба „%s“ не захтева аргумент"
+
+#: src/conf.c:1300
+#, c-format
+msgid "line %d: an account name must not contain colons or commas"
+msgstr "%d. ред: назив налога не сме да садржи двотачке или зарезе"
+
+#: src/conf.c:1310
+#, c-format
+msgid "line %d: account %s was already defined"
+msgstr "%d. ред: налог „%s“ је већ дефинисан"
+
+#: src/conf.c:1365 src/conf.c:1397 src/conf.c:1428 src/conf.c:1462
+#: src/conf.c:1488 src/conf.c:1534 src/conf.c:1554 src/conf.c:1639
+#: src/conf.c:1660 src/conf.c:1679 src/conf.c:1740 src/conf.c:1771
+#: src/conf.c:1821 src/conf.c:1868 src/conf.c:1893 src/conf.c:1913
+#: src/conf.c:1933 src/conf.c:1953 src/conf.c:1973 src/conf.c:2020
+#: src/conf.c:2041 src/conf.c:2062 src/conf.c:2090
 #, c-format
 msgid "line %d: invalid argument %s for command %s"
 msgstr "%d. ред: неисправан аргумент „%s“ за наредбу „%s“"
 
-#: src/conf.c:2093
+#: src/conf.c:2136
 #, c-format
 msgid "line %d: unknown command %s"
 msgstr "%d. ред: непозната наредба „%s“"
 
-#: src/conf.c:2145
+#: src/conf.c:2190
 #, c-format
 msgid "contains secrets and therefore must be owned by you"
 msgstr "садржи тајне и стога мора бити у вашем власништву"
 
-#: src/conf.c:2151
+#: src/conf.c:2196
 #, c-format
 msgid ""
 "contains secrets and therefore must have no more than user read/write "
@@ -159,101 +159,101 @@ msgstr ""
 
 #. TRANSLATORS: msmtp shares a lot of code and translatable strings with
 #. mpop <https://marlam.de/mpop>.
-#: src/msmtp.c:88
+#: src/msmtp.c:90
 #, c-format
 msgid "%s: FATAL: %s\n"
 msgstr "%s: КОБНО: %s\n"
 
-#: src/msmtp.c:228 src/msmtp.c:406 src/msmtp.c:1401
+#: src/msmtp.c:230 src/msmtp.c:408 src/msmtp.c:1522
 #, c-format
 msgid "the server does not support TLS via the STARTTLS command"
 msgstr "сервер не подржава „TLS“ путем „STARTTLS“ наредбе"
 
-#: src/msmtp.c:270
+#: src/msmtp.c:272
 #, c-format
 msgid "the server does not support Remote Message Queue Starting"
 msgstr "сервер не подржава започињање реда удаљене поруке"
 
-#: src/msmtp.c:282 src/msmtp.c:1459
+#: src/msmtp.c:284 src/msmtp.c:1580
 #, c-format
 msgid "the server does not support authentication"
 msgstr "сервер не подржава потврђивање идентитета"
 
-#: src/msmtp.c:441
+#: src/msmtp.c:443
 #, c-format
 msgid "%s server at %s (%s [%s]), port %d:\n"
 msgstr "„%s“ сервер на „%s“ (%s [%s]), прикључник %d:\n"
 
-#: src/msmtp.c:447
+#: src/msmtp.c:450
 #, c-format
 msgid "%s server at %s (%s), port %d:\n"
 msgstr "„%s“ сервер на „%s“ (%s), прикључник %d:\n"
 
-#: src/msmtp.c:453
+#: src/msmtp.c:457
 #, c-format
 msgid "%s server at %s ([%s]), port %d:\n"
 msgstr "„%s“ сервер на „%s“ ([%s]), прикључник %d:\n"
 
-#: src/msmtp.c:459
+#: src/msmtp.c:464
 #, c-format
 msgid "%s server at %s, port %d:\n"
 msgstr "„%s“ сервер на „%s“, прикључник %d:\n"
 
-#: src/msmtp.c:479
+#: src/msmtp.c:485
 #, c-format
 msgid "No special capabilities.\n"
 msgstr "Нема нарочитих могућности.\n"
 
-#: src/msmtp.c:483
+#: src/msmtp.c:489
 #, c-format
 msgid "Capabilities:\n"
 msgstr "Могућности:\n"
 
-#: src/msmtp.c:487
+#: src/msmtp.c:493
 msgid "Maximum message size is "
 msgstr "Највећа величина поруке је "
 
-#: src/msmtp.c:490
+#: src/msmtp.c:496
 #, c-format
 msgid "unlimited\n"
 msgstr "неограничено\n"
 
-#: src/msmtp.c:494
+#: src/msmtp.c:500
 #, c-format
 msgid "%ld bytes"
 msgstr "%ld бајта"
 
-#: src/msmtp.c:497
+#: src/msmtp.c:503
 #, c-format
 msgid " = %.2f MiB"
 msgstr " = %.2f MiB"
 
-#: src/msmtp.c:502
+#: src/msmtp.c:508
 #, c-format
 msgid " = %.2f KiB"
 msgstr " = %.2f KiB"
 
-#: src/msmtp.c:509
+#: src/msmtp.c:515
 msgid "Support for command grouping for faster transmission"
 msgstr "Подршка за груписање наредби ради бржег преноса"
 
-#: src/msmtp.c:514
+#: src/msmtp.c:520
 msgid "Support for RMQS (Remote Message Queue Starting)"
 msgstr "Подршка за „RMQS“ (започињање реда удаљене поруке)"
 
-#: src/msmtp.c:519
+#: src/msmtp.c:525
 msgid "Support for Delivery Status Notifications"
 msgstr "Подршка за обавештења стања испоруке"
 
-#: src/msmtp.c:529
+#: src/msmtp.c:535
 msgid "Support for TLS encryption via the STARTTLS command"
 msgstr "Подршка за „TLS“ шифровање путем наредбе „STARTTLS“"
 
-#: src/msmtp.c:535
+#: src/msmtp.c:541
 msgid "Supported authentication methods:"
 msgstr "Подржани начини потврђивања идентитета:"
 
-#: src/msmtp.c:588
+#: src/msmtp.c:594
 #, c-format
 msgid ""
 "This server might advertise more or other capabilities when TLS is active.\n"
@@ -261,111 +261,111 @@ msgstr ""
 "Овај сервер може обавестити о више или о другим могућностима када је „TLS“ "
 "активно.\n"
 
-#: src/msmtp.c:1153 src/msmtp.c:3299
+#: src/msmtp.c:1274 src/msmtp.c:3447
 #, c-format
 msgid "cannot write mail headers to temporary file: output error"
 msgstr "не могу да пишем заглавља поште у привремену датотеку: излазна грешка"
 
-#: src/msmtp.c:1261
+#: src/msmtp.c:1382
 #, c-format
 msgid "input error while reading the mail"
 msgstr "улазна грешка приликом читања поште"
 
-#: src/msmtp.c:1448
+#: src/msmtp.c:1569
 #, c-format
 msgid "the server does not support DSN"
 msgstr "сервер не подржава „DSN“"
 
-#: src/msmtp.c:1597 src/msmtp.c:1616 src/msmtp.c:1668
+#: src/msmtp.c:1718 src/msmtp.c:1737 src/msmtp.c:1789
 #, c-format
 msgid "automatic configuration based on SRV records failed: %s"
 msgstr "самоподешавање на основу „SRV“ снимака није успело: %s"
 
-#: src/msmtp.c:1598
+#: src/msmtp.c:1719
 msgid "invalid mail address"
 msgstr "нетачна адреса е-поште"
 
-#: src/msmtp.c:1614
+#: src/msmtp.c:1735
 #, c-format
 msgid "no SRV records for %s or %s"
 msgstr "нема „SRV“ снимака за „%s“ или „%s“"
 
-#: src/msmtp.c:1631
+#: src/msmtp.c:1752
 #, c-format
 msgid "copy this to your configuration file %s"
 msgstr "умножите ово у вашу датотеку подешавања „%s“"
 
-#: src/msmtp.c:1635
+#: src/msmtp.c:1756
 msgid "warning: the host does not match the mail domain; please check"
 msgstr "упозорење: домаћин не одговара домену поште; проверите то"
 
-#: src/msmtp.c:1638 src/msmtp.c:1642
+#: src/msmtp.c:1759 src/msmtp.c:1763
 msgid "add your password to the key ring:"
 msgstr "додајте вашу лозинку у привезак кључева:"
 
-#: src/msmtp.c:1645
+#: src/msmtp.c:1766
 msgid "encrypt your password:"
 msgstr "шифрујте вашу лозинку:"
 
-#: src/msmtp.c:1669
+#: src/msmtp.c:1790
 msgid "this system lacks libresolv"
 msgstr "овом систему недостаје „libresolv“"
 
-#: src/msmtp.c:1896
+#: src/msmtp.c:2022
 #, c-format
 msgid "invalid logfile_time_format"
 msgstr "неисправан запис_времена_дневника"
 
-#: src/msmtp.c:1909
+#: src/msmtp.c:2035
 #, c-format
 msgid "cannot open: %s"
 msgstr "не могу да отворим: %s"
 
-#: src/msmtp.c:1917
+#: src/msmtp.c:2043
 #, c-format
 msgid "cannot lock (tried for %d seconds): %s"
 msgstr "не могу да закључам (покушах %d секунде): %s"
 
-#: src/msmtp.c:1922
+#: src/msmtp.c:2048
 #, c-format
 msgid "cannot lock: %s"
 msgstr "не могу да закључам: %s"
 
-#: src/msmtp.c:1931
+#: src/msmtp.c:2057
 msgid "output error"
 msgstr "излазна грешка"
 
-#: src/msmtp.c:1948
+#: src/msmtp.c:2074
 #, c-format
 msgid "cannot log to %s: %s"
 msgstr "не могу да упишем дневник у „%s“: %s"
 
-#: src/msmtp.c:1952
+#: src/msmtp.c:2078
 #, c-format
 msgid "log info was: %s"
 msgstr "подаци дневника беху: %s"
 
-#: src/msmtp.c:2061
+#: src/msmtp.c:2187
 #, c-format
 msgid "%s version %s\n"
 msgstr "%s издање %s\n"
 
-#: src/msmtp.c:2062
+#: src/msmtp.c:2188
 #, c-format
 msgid "Platform: %s\n"
 msgstr "Платформа: %s\n"
 
-#: src/msmtp.c:2064
+#: src/msmtp.c:2190
 #, c-format
 msgid "TLS/SSL library: %s\n"
 msgstr "„TLS/SSL“ библиотека: %s\n"
 
-#: src/msmtp.c:2072 src/msmtp.c:2150
+#: src/msmtp.c:2198 src/msmtp.c:2276
 #, c-format
 msgid "none"
 msgstr "ништа"
 
-#: src/msmtp.c:2076
+#: src/msmtp.c:2202
 #, c-format
 msgid ""
 "Authentication library: %s\n"
@@ -374,65 +374,65 @@ msgstr ""
 "Библиотека потврђивања идентитета: %s\n"
 "Подржани начини потврђивања идентитета:\n"
 
-#: src/msmtp.c:2079
+#: src/msmtp.c:2205
 msgid "GNU SASL; oauthbearer and xoauth2: built-in"
 msgstr "GNU SASL; oauthbearer и xoauth2: уграђено"
 
-#: src/msmtp.c:2081
+#: src/msmtp.c:2207
 msgid "built-in"
 msgstr "уграђено"
 
-#: src/msmtp.c:2130
+#: src/msmtp.c:2256
 #, c-format
 msgid "IDN support: "
 msgstr "„IDN“ подршка: "
 
-#: src/msmtp.c:2134 src/msmtp.c:2142
+#: src/msmtp.c:2260 src/msmtp.c:2268
 #, c-format
 msgid "enabled"
 msgstr "омогућено"
 
-#: src/msmtp.c:2136 src/msmtp.c:2145
+#: src/msmtp.c:2262 src/msmtp.c:2271
 #, c-format
 msgid "disabled"
 msgstr "онемогућено"
 
-#: src/msmtp.c:2140
+#: src/msmtp.c:2266
 #, c-format
 msgid "NLS: "
 msgstr "NLS: "
 
-#: src/msmtp.c:2143
+#: src/msmtp.c:2269
 #, c-format
 msgid ", LOCALEDIR is %s"
 msgstr ", ДИРЈЕЗИКА ЈЕ „%s“"
 
-#: src/msmtp.c:2148
+#: src/msmtp.c:2274
 #, c-format
 msgid "Keyring support: "
 msgstr "Подршка привеска кључева: "
 
-#: src/msmtp.c:2153
+#: src/msmtp.c:2279
 #, c-format
 msgid "Gnome "
 msgstr "Гном "
 
-#: src/msmtp.c:2156
+#: src/msmtp.c:2282
 #, c-format
 msgid "MacOS "
 msgstr "MacOS "
 
-#: src/msmtp.c:2162
+#: src/msmtp.c:2288
 #, c-format
 msgid "System configuration file name: %s\n"
 msgstr "Датотека подешавања система: %s\n"
 
-#: src/msmtp.c:2166
+#: src/msmtp.c:2292
 #, c-format
 msgid "User configuration file name: %s\n"
 msgstr "Датотека подешавања корисника: %s\n"
 
-#: src/msmtp.c:2169
+#: src/msmtp.c:2295
 #, c-format
 msgid ""
 "Copyright (C) %d Martin Lambers and others.\n"
@@ -447,7 +447,7 @@ msgstr ""
 "Гнуове Опште Јавне Лиценце <http://www.gnu.org/licenses/gpl.html>.\n"
 "Не постоји НИКАКВА ГАРАНЦИЈА, у оквирима дозвољеним законом.\n"
 
-#: src/msmtp.c:2186
+#: src/msmtp.c:2312
 #, c-format
 msgid ""
 "Usage:\n"
@@ -456,7 +456,7 @@ msgstr ""
 "Употреба:\n"
 "\n"
 
-#: src/msmtp.c:2187
+#: src/msmtp.c:2313
 #, c-format
 msgid ""
 "Sendmail mode (default):\n"
@@ -471,7 +471,7 @@ msgstr ""
 "  Чита пошту са стандардног улаза и пребацује је на „SMTP“ или „LMTP“ "
 "сервер.\n"
 
-#: src/msmtp.c:2192
+#: src/msmtp.c:2318
 #, c-format
 msgid ""
 "Configuration mode:\n"
@@ -482,7 +482,7 @@ msgstr ""
 "  %s --configure=адреса_поште\n"
 "  Ствара и исписује подешавање за адресу.\n"
 
-#: src/msmtp.c:2195
+#: src/msmtp.c:2321
 #, c-format
 msgid ""
 "Server information mode:\n"
@@ -493,7 +493,7 @@ msgstr ""
 "  %s [опција...] --serverinfo\n"
 "  Исписује податке о серверу.\n"
 
-#: src/msmtp.c:2198
+#: src/msmtp.c:2324
 #, c-format
 msgid ""
 "Remote Message Queue Starting mode:\n"
@@ -506,67 +506,67 @@ msgstr ""
 "  Шаље серверу захтев започињања реда удаљене поруке.\n"
 "\n"
 
-#: src/msmtp.c:2202
+#: src/msmtp.c:2328
 #, c-format
 msgid "General options:\n"
 msgstr "Опште опције:\n"
 
-#: src/msmtp.c:2203
+#: src/msmtp.c:2329
 #, c-format
 msgid "  --version                    print version\n"
 msgstr "  --version                      исписује издање\n"
 
-#: src/msmtp.c:2204
+#: src/msmtp.c:2330
 #, c-format
 msgid "  --help                       print help\n"
 msgstr "  --help                         исписује помоћ\n"
 
-#: src/msmtp.c:2205
+#: src/msmtp.c:2331
 #, c-format
 msgid "  -P, --pretend                print configuration info and exit\n"
 msgstr ""
 "  -P, --pretend                  исписује податке подешавања и излази\n"
 
-#: src/msmtp.c:2206
+#: src/msmtp.c:2332
 #, c-format
 msgid "  -d, --debug                  print debugging information\n"
 msgstr "  -d, --debug                    исписује податке пречишћавања\n"
 
-#: src/msmtp.c:2207
+#: src/msmtp.c:2333
 #, c-format
 msgid "Changing the mode of operation:\n"
 msgstr "Промена режима рада:\n"
 
-#: src/msmtp.c:2208
+#: src/msmtp.c:2334
 #, c-format
 msgid ""
 "  --configure=mailaddress      generate and print configuration for address\n"
 msgstr ""
 "  --configure=адреса_поште       ствара и исписује подешавање за адресу\n"
 
-#: src/msmtp.c:2209
+#: src/msmtp.c:2335
 #, c-format
 msgid "  -S, --serverinfo             print information about the server\n"
 msgstr "  -S, --serverinfo               исписује податке о серверу\n"
 
-#: src/msmtp.c:2210
+#: src/msmtp.c:2336
 #, c-format
 msgid ""
 "  --rmqs=host|@domain|#queue   send a Remote Message Queue Starting request\n"
 msgstr ""
 "  --rmqs=домаћин|@домен|#ред     шаље захтев започињања реда удаљене поруке\n"
 
-#: src/msmtp.c:2211
+#: src/msmtp.c:2337
 #, c-format
 msgid "Configuration options:\n"
 msgstr "Опције подешавања:\n"
 
-#: src/msmtp.c:2212
+#: src/msmtp.c:2338
 #, c-format
 msgid "  -C, --file=filename          set configuration file\n"
 msgstr "  -C, --file=датотека            поставља датотеку подешавања\n"
 
-#: src/msmtp.c:2213
+#: src/msmtp.c:2339
 #, c-format
 msgid ""
 "  -a, --account=id             use the given account instead of the account\n"
@@ -579,7 +579,7 @@ msgstr ""
 "могу изменити\n"
 "                                 опцијама линије наредби\n"
 
-#: src/msmtp.c:2216
+#: src/msmtp.c:2342
 #, c-format
 msgid ""
 "  --host=hostname              set the server, use only command-line "
@@ -591,12 +591,12 @@ msgstr ""
 "                                 не користи никакве податке датотеке "
 "подешавања\n"
 
-#: src/msmtp.c:2218
+#: src/msmtp.c:2344
 #, c-format
 msgid "  --port=number                set port number\n"
 msgstr "  --port=број                    подешава број прикључника\n"
 
-#: src/msmtp.c:2219
+#: src/msmtp.c:2345
 #, c-format
 msgid ""
 "  --source-ip=[IP]             set/unset source ip address to bind the "
@@ -605,37 +605,37 @@ msgstr ""
 "  --source-ip=[ИП]               подешава/расподешава ип адресу извора на "
 "коју ће свезати прикључницу\n"
 
-#: src/msmtp.c:2220
+#: src/msmtp.c:2346
 #, c-format
 msgid "  --proxy-host=[IP|hostname]   set/unset proxy\n"
 msgstr "  --proxy-host=[ИП|домаћин]      подешава/расподешава посредника\n"
 
-#: src/msmtp.c:2221
+#: src/msmtp.c:2347
 #, c-format
 msgid "  --proxy-port=[number]        set/unset proxy port\n"
 msgstr ""
 "  --proxy-port=[број]            подешава/расподешава прикључник посредника\n"
 
-#: src/msmtp.c:2222
+#: src/msmtp.c:2348
 #, c-format
 msgid "  --socket=[socketname]        set/unset local socket to connect to\n"
 msgstr ""
 "  --socket=[прикључница]         подешава/расподешава локалну прикључницу на "
 "коју ће се повезати\n"
 
-#: src/msmtp.c:2223
+#: src/msmtp.c:2349
 #, c-format
 msgid "  --timeout=(off|seconds)      set/unset network timeout in seconds\n"
 msgstr ""
 "  --timeout=(искљ.|сек.)         подешава/расподешава време истека мреже у "
 "секундама\n"
 
-#: src/msmtp.c:2224
+#: src/msmtp.c:2350
 #, c-format
 msgid "  --protocol=(smtp|lmtp)       use the given sub protocol\n"
 msgstr "  --protocol=(smtp|lmtp)         користи дати подпротокол\n"
 
-#: src/msmtp.c:2225
+#: src/msmtp.c:2351
 #, c-format
 msgid ""
 "  --domain=string              set the argument of EHLO or LHLO command\n"
@@ -643,7 +643,7 @@ msgstr ""
 "  --domain=ниска                 подешава аргумент „EHLO“ или „LHLO“ "
 "наредбе\n"
 
-#: src/msmtp.c:2226
+#: src/msmtp.c:2352
 #, c-format
 msgid ""
 "  --auth[=(on|off|method)]     enable/disable authentication and optionally\n"
@@ -653,46 +653,46 @@ msgstr ""
 "идентитета и\n"
 "                                 опционално бира начин\n"
 
-#: src/msmtp.c:2228
+#: src/msmtp.c:2354
 #, c-format
 msgid "  --user=[username]            set/unset user name for authentication\n"
 msgstr ""
 "  --user=[корисник]              подешава/расподешава корисничко име за "
 "потврђивање идентитета\n"
 
-#: src/msmtp.c:2229
+#: src/msmtp.c:2355
 #, c-format
 msgid "  --passwordeval=[eval]        evaluate password for authentication\n"
 msgstr ""
 "  --passwordeval=[оцењ]          оцењује лозинку за потврђивање идентитета\n"
 
-#: src/msmtp.c:2230
+#: src/msmtp.c:2356
 #, c-format
 msgid "  --tls[=(on|off)]             enable/disable TLS encryption\n"
 msgstr ""
 "  --tls[=(укљ|искљ)]             омогућује/онемогућује „TLS“ шифровање\n"
 
-#: src/msmtp.c:2231
+#: src/msmtp.c:2357
 #, c-format
 msgid "  --tls-starttls[=(on|off)]    enable/disable STARTTLS for TLS\n"
 msgstr ""
 "  --tls-starttls[=(укљ|искљ)]    омогућује/онемогућује „STARTTLS“ за „TLS“\n"
 
-#: src/msmtp.c:2232
+#: src/msmtp.c:2358
 #, c-format
 msgid "  --tls-trust-file=[file]      set/unset trust file for TLS\n"
 msgstr ""
 "  --tls-trust-file=[датотека]    подешава/расподешава датотеку поверења за "
 "„TLS“\n"
 
-#: src/msmtp.c:2233
+#: src/msmtp.c:2359
 #, c-format
 msgid "  --tls-crl-file=[file]        set/unset revocation file for TLS\n"
 msgstr ""
 "  --tls-crl-file=[датотека]      подешава/расподешава датотеку опозивања за "
 "„TLS“\n"
 
-#: src/msmtp.c:2234
+#: src/msmtp.c:2360
 #, c-format
 msgid ""
 "  --tls-fingerprint=[f]        set/unset trusted certificate fingerprint for "
@@ -701,7 +701,7 @@ msgstr ""
 "  --tls-fingerprint=[ф]          подешава/расподешава отисак поверљивог "
 "уверења за „TLS“\n"
 
-#: src/msmtp.c:2235
+#: src/msmtp.c:2361
 #, c-format
 msgid ""
 "  --tls-certcheck[=(on|off)]   enable/disable server certificate checks for "
@@ -710,27 +710,27 @@ msgstr ""
 "  --tls-certcheck[=(укљ|искљ)]   подешава/расподешава провере уверења "
 "сервера за „TLS“\n"
 
-#: src/msmtp.c:2236
+#: src/msmtp.c:2362
 #, c-format
 msgid "  --tls-key-file=[file]        set/unset private key file for TLS\n"
 msgstr ""
 "  --tls-key-file=[датотека]      подешава/расподешава датотеку личног кључа "
 "за „TLS“\n"
 
-#: src/msmtp.c:2237
+#: src/msmtp.c:2363
 #, c-format
 msgid "  --tls-cert-file=[file]       set/unset private cert file for TLS\n"
 msgstr ""
 "  --tls-cert-file=[датотека]     подешава/расподешава датотеку личног "
 "уверења за „TLS“\n"
 
-#: src/msmtp.c:2238
+#: src/msmtp.c:2364
 #, c-format
 msgid "  --tls-priorities=[prios]     set/unset TLS priorities.\n"
 msgstr ""
 "  --tls-priorities=[приор]       подешава/расподешава „TLS“ приоритете.\n"
 
-#: src/msmtp.c:2239
+#: src/msmtp.c:2365
 #, c-format
 msgid ""
 "  --tls-host-override=[host]   set/unset override for TLS host "
@@ -739,19 +739,19 @@ msgstr ""
 "  --tls-host-override=[домаћин]  подешава/расподешава прескок за проверу "
 "„TLS“ домаћина.\n"
 
-#: src/msmtp.c:2240
+#: src/msmtp.c:2366
 #, c-format
 msgid "  --tls-min-dh-prime-bits=[b]  set/unset minimum bit size of DH prime\n"
 msgstr ""
 "  --tls-min-dh-prime-bits=[б]    подешава/расподешава најмању величину бита "
 "„DH“ простог броја\n"
 
-#: src/msmtp.c:2241
+#: src/msmtp.c:2367
 #, c-format
 msgid "Options specific to sendmail mode:\n"
 msgstr "Опције специфичне режиму слања поште:\n"
 
-#: src/msmtp.c:2242
+#: src/msmtp.c:2368
 #, c-format
 msgid ""
 "  --auto-from[=(on|off)]       enable/disable automatic envelope-from "
@@ -760,12 +760,12 @@ msgstr ""
 "  --auto-from[=(укљ|искљ)]       омогућује/онемогућује аутоматске адресе за "
 "„коверту-шаље“\n"
 
-#: src/msmtp.c:2243
+#: src/msmtp.c:2369
 #, c-format
 msgid "  -f, --from=address           set envelope from address\n"
 msgstr "  -f, --from=адреса              подешава адресу за „коверту шаље“\n"
 
-#: src/msmtp.c:2244
+#: src/msmtp.c:2370
 #, c-format
 msgid ""
 "  --maildomain=[domain]        set the domain for automatic envelope from\n"
@@ -774,23 +774,23 @@ msgstr ""
 "  --maildomain=[домен]           подешава домен за аутоматске адресе за\n"
 "                                 „коверту шаље“\n"
 
-#: src/msmtp.c:2246
+#: src/msmtp.c:2372
 #, c-format
 msgid "  -N, --dsn-notify=(off|cond)  set/unset DSN conditions\n"
 msgstr "  -N, --dsn-notify=(искљ|усл)    подешава/расподешава „DSN“ услове\n"
 
-#: src/msmtp.c:2247
+#: src/msmtp.c:2373
 #, c-format
 msgid "  -R, --dsn-return=(off|ret)   set/unset DSN amount\n"
 msgstr "  -R, --dsn-return=(искљ|врат)   подешава/расподешава „DSN“ износ\n"
 
-#: src/msmtp.c:2248
+#: src/msmtp.c:2374
 #, c-format
 msgid "  -X, --logfile=[file]         set/unset log file\n"
 msgstr ""
 "  -X, --logfile=[датотека]       подешава/расподешава датотеку дневника\n"
 
-#: src/msmtp.c:2249
+#: src/msmtp.c:2375
 #, c-format
 msgid ""
 "  --logfile-time-format=[fmt]  set/unset log file time format for "
@@ -799,7 +799,7 @@ msgstr ""
 "  --logfile-time-format=[зпв]    подешава/расподешава запис времена датотеке "
 "дневника за „strftime()“\n"
 
-#: src/msmtp.c:2250
+#: src/msmtp.c:2376
 #, c-format
 msgid ""
 "  --syslog[=(on|off|facility)] enable/disable/configure syslog logging\n"
@@ -807,38 +807,45 @@ msgstr ""
 "  --syslog[=(укљ|искљ|олакш)]    омогућава/онемогућава/подешава вођење "
 "сситемског дневника\n"
 
-#: src/msmtp.c:2251
+#: src/msmtp.c:2377
 #, c-format
 msgid ""
 "  -t, --read-recipients        read additional recipients from the mail\n"
 msgstr "  -t, --read-recipients          чита додатне примаоце из поште\n"
 
-#: src/msmtp.c:2252
+#: src/msmtp.c:2378
 #, c-format
 msgid ""
 "  --read-envelope-from         read envelope from address from the mail\n"
 msgstr ""
 "  --read-envelope-from           чита даресу за „коверту шаље“ из поште\n"
 
-#: src/msmtp.c:2253
+#: src/msmtp.c:2379
 #, c-format
 msgid "  --aliases=[file]             set/unset aliases file\n"
 msgstr ""
 "  --aliases=[датотека]           подешава/расподешава датотеку алијаса\n"
 
-#: src/msmtp.c:2254
+#: src/msmtp.c:2380
 #, c-format
 msgid "  --set-from-header[=(auto|on|off)] set From header handling\n"
 msgstr ""
 "  --set-from-header[=(ауто|укљ|искљ)] подешава руковање заглављем пошиљаоца\n"
 
-#: src/msmtp.c:2255
+#: src/msmtp.c:2381
 #, c-format
 msgid "  --set-date-header[=(auto|off)] set Date header handling\n"
 msgstr ""
 "  --set-date-header[=(ауто|искљ)]  подешава руковање заглављем датума\n"
 
-#: src/msmtp.c:2256
+#: src/msmtp.c:2382
+#, fuzzy, c-format
+#| msgid "  --set-date-header[=(auto|off)] set Date header handling\n"
+msgid "  --set-msgid-header[=(auto|off)] set Message-ID header handling\n"
+msgstr ""
+"  --set-date-header[=(ауто|искљ)]  подешава руковање заглављем датума\n"
+
+#: src/msmtp.c:2383
 #, c-format
 msgid ""
 "  --remove-bcc-headers[=(on|off)] enable/disable removal of Bcc headers\n"
@@ -846,7 +853,7 @@ msgstr ""
 "  --remove-bcc-headers[=(укљ|искљ)] омогућује/онемогућује уклањање заглавља "
 "угљених умножака\n"
 
-#: src/msmtp.c:2257
+#: src/msmtp.c:2384
 #, c-format
 msgid ""
 "  --undisclosed-recipients[=(on|off)] enable/disable replacement of To/Cc/"
@@ -857,12 +864,12 @@ msgstr ""
 "Уу/Суу“\n"
 "                               са „Прима: необјављени-примаоци:“;\n"
 
-#: src/msmtp.c:2259
+#: src/msmtp.c:2386
 #, c-format
 msgid "  --                           end of options\n"
 msgstr "  --                             крај опција\n"
 
-#: src/msmtp.c:2260
+#: src/msmtp.c:2387
 #, c-format
 msgid ""
 "Accepted but ignored: -A, -B, -bm, -F, -G, -h, -i, -L, -m, -n, -O, -o, -v\n"
@@ -870,7 +877,7 @@ msgstr ""
 "Прихваћене али занемарене су: -A, -B, -bm, -F, -G, -h, -i, -L, -m, -n, -O, -"
 "o, -v\n"
 
-#: src/msmtp.c:2261
+#: src/msmtp.c:2388
 #, c-format
 msgid ""
 "\n"
@@ -879,235 +886,235 @@ msgstr ""
 "\n"
 "Грешке пријавите на <%s>.\n"
 
-#: src/msmtp.c:2503 src/msmtp.c:2517
+#: src/msmtp.c:2633 src/msmtp.c:2647
 msgid "cannot use both --serverinfo and --rmqs"
 msgstr "не можете користити и „--serverinfo“ и „--rmqs“"
 
-#: src/msmtp.c:2537 src/msmtp.c:2549
+#: src/msmtp.c:2667 src/msmtp.c:2679
 msgid "cannot use both --host and --account"
 msgstr "не можете користити и „--host“ и „--account“"
 
-#: src/msmtp.c:2565 src/msmtp.c:2583 src/msmtp.c:2602 src/msmtp.c:2657
-#: src/msmtp.c:2689 src/msmtp.c:2707 src/msmtp.c:2770 src/msmtp.c:2815
-#: src/msmtp.c:2837 src/msmtp.c:2883 src/msmtp.c:2908 src/msmtp.c:2927
-#: src/msmtp.c:2980 src/msmtp.c:3025 src/msmtp.c:3052 src/msmtp.c:3070
-#: src/msmtp.c:3089 src/msmtp.c:3108 src/msmtp.c:3126 src/msmtp.c:3144
-#: src/msmtp.c:3221
+#: src/msmtp.c:2695 src/msmtp.c:2713 src/msmtp.c:2732 src/msmtp.c:2787
+#: src/msmtp.c:2819 src/msmtp.c:2837 src/msmtp.c:2900 src/msmtp.c:2945
+#: src/msmtp.c:2967 src/msmtp.c:3013 src/msmtp.c:3038 src/msmtp.c:3057
+#: src/msmtp.c:3110 src/msmtp.c:3155 src/msmtp.c:3182 src/msmtp.c:3200
+#: src/msmtp.c:3218 src/msmtp.c:3237 src/msmtp.c:3256 src/msmtp.c:3274
+#: src/msmtp.c:3292 src/msmtp.c:3369
 #, c-format
 msgid "invalid argument %s for %s"
 msgstr "неисправан аргумент „%s“ за „%s“"
 
-#: src/msmtp.c:2612 src/msmtp.c:3184
+#: src/msmtp.c:2742 src/msmtp.c:3332
 msgid "cannot use both --from and --read-envelope-from"
 msgstr "не можете користити и „--from“ и „--read-envelope-from“"
 
-#: src/msmtp.c:3199
+#: src/msmtp.c:3347
 #, c-format
 msgid "unsupported operation mode b%s"
 msgstr "неподржан режим радње „b%s“"
 
-#: src/msmtp.c:3276 src/msmtp.c:3753 src/msmtp.c:4052
+#: src/msmtp.c:3424 src/msmtp.c:3904 src/msmtp.c:4204
 #, c-format
 msgid "cannot create temporary file: %s"
 msgstr "не могу да направим привремену датотеку: %s"
 
-#: src/msmtp.c:3306 src/msmtp.c:3778 src/msmtp.c:4085
+#: src/msmtp.c:3454 src/msmtp.c:3930 src/msmtp.c:4243
 #, c-format
 msgid "cannot rewind temporary file: %s"
 msgstr "не могу да премотам привремену датотеку: %s"
 
-#: src/msmtp.c:3371
+#: src/msmtp.c:3520
 #, c-format
 msgid "ignoring system configuration file %s: %s\n"
 msgstr "занемарујем системску датотеку подешавања „%s“: %s\n"
 
-#: src/msmtp.c:3386
+#: src/msmtp.c:3535
 #, c-format
 msgid "loaded system configuration file %s\n"
 msgstr "учитах системску датотеку подешавања „%s“\n"
 
-#: src/msmtp.c:3425
+#: src/msmtp.c:3574
 #, c-format
 msgid "ignoring user configuration file %s: %s\n"
 msgstr "занемарујем корисничку датотеку подешавања „%s“: %s\n"
 
-#: src/msmtp.c:3440
+#: src/msmtp.c:3589
 #, c-format
 msgid "loaded user configuration file %s\n"
 msgstr "учитах корисничку датотеку подешавања „%s“\n"
 
-#: src/msmtp.c:3497
+#: src/msmtp.c:3646
 #, c-format
 msgid "using account %s from %s\n"
 msgstr "користим налог „%s“ са „%s“\n"
 
-#: src/msmtp.c:3503 src/msmtp.c:3505 src/msmtp.c:3508 src/msmtp.c:3542
-#: src/msmtp.c:3543 src/msmtp.c:3545 src/msmtp.c:3547 src/msmtp.c:3551
-#: src/msmtp.c:3553 src/msmtp.c:3572 src/msmtp.c:3574 src/msmtp.c:3576
-#: src/msmtp.c:3586 src/msmtp.c:3589 src/msmtp.c:3591 src/msmtp.c:3596
-#: src/msmtp.c:3599 src/msmtp.c:3611 src/msmtp.c:3613 src/msmtp.c:3615
-#: src/msmtp.c:3618 src/msmtp.c:3620 src/msmtp.c:3622
+#: src/msmtp.c:3650 src/msmtp.c:3653 src/msmtp.c:3655 src/msmtp.c:3658
+#: src/msmtp.c:3692 src/msmtp.c:3693 src/msmtp.c:3695 src/msmtp.c:3697
+#: src/msmtp.c:3701 src/msmtp.c:3703 src/msmtp.c:3722 src/msmtp.c:3724
+#: src/msmtp.c:3726 src/msmtp.c:3736 src/msmtp.c:3739 src/msmtp.c:3741
+#: src/msmtp.c:3746 src/msmtp.c:3749 src/msmtp.c:3761 src/msmtp.c:3763
+#: src/msmtp.c:3765 src/msmtp.c:3768 src/msmtp.c:3770 src/msmtp.c:3772
 msgid "(not set)"
 msgstr "(није подешено)"
 
-#: src/msmtp.c:3512
+#: src/msmtp.c:3662
 #, c-format
 msgid "off\n"
 msgstr "искљ\n"
 
-#: src/msmtp.c:3518
+#: src/msmtp.c:3668
 #, c-format
 msgid "%d seconds\n"
 msgstr "%d секунде\n"
 
-#: src/msmtp.c:3522
+#: src/msmtp.c:3672
 #, c-format
 msgid "1 second\n"
 msgstr "1 секунда\n"
 
-#: src/msmtp.c:3531
+#: src/msmtp.c:3681
 #, c-format
 msgid "none\n"
 msgstr "ништа\n"
 
-#: src/msmtp.c:3535
+#: src/msmtp.c:3685
 #, c-format
 msgid "choose\n"
 msgstr "изабери\n"
 
-#: src/msmtp.c:3548 src/msmtp.c:3549 src/msmtp.c:3578 src/msmtp.c:3594
-#: src/msmtp.c:3602 src/msmtp.c:3607 src/msmtp.c:3609
+#: src/msmtp.c:3698 src/msmtp.c:3699 src/msmtp.c:3728 src/msmtp.c:3744
+#: src/msmtp.c:3752 src/msmtp.c:3757 src/msmtp.c:3759
 msgid "on"
 msgstr "укљ"
 
-#: src/msmtp.c:3548 src/msmtp.c:3549 src/msmtp.c:3578 src/msmtp.c:3594
-#: src/msmtp.c:3602 src/msmtp.c:3605 src/msmtp.c:3607 src/msmtp.c:3609
+#: src/msmtp.c:3698 src/msmtp.c:3699 src/msmtp.c:3728 src/msmtp.c:3744
+#: src/msmtp.c:3752 src/msmtp.c:3755 src/msmtp.c:3757 src/msmtp.c:3759
 msgid "off"
 msgstr "искљ"
 
-#: src/msmtp.c:3599
+#: src/msmtp.c:3749
 msgid "(read from mail)"
 msgstr "(читам из поште)"
 
-#: src/msmtp.c:3601 src/msmtp.c:3604
+#: src/msmtp.c:3751 src/msmtp.c:3754
 msgid "auto"
 msgstr "самостално"
 
-#: src/msmtp.c:3625
+#: src/msmtp.c:3775
 #, c-format
 msgid "reading recipients from the command line and the mail\n"
 msgstr "читам примаоце са линије наредби и из поште\n"
 
-#: src/msmtp.c:3630
+#: src/msmtp.c:3780
 #, c-format
 msgid "reading recipients from the command line\n"
 msgstr "читам примаоце са линије наредби\n"
 
-#: src/msmtp.c:3743
+#: src/msmtp.c:3894
 msgid "too many arguments"
 msgstr "превише аргумената"
 
-#: src/msmtp.c:3772
+#: src/msmtp.c:3924
 #, c-format
 msgid "envelope from address extracted from mail: %s\n"
 msgstr "адреса за „коверту шаље“ извучена из поште: %s\n"
 
-#: src/msmtp.c:3787
+#: src/msmtp.c:3939
 msgid "no recipients found"
 msgstr "нисам нашао примаоце"
 
-#: src/msmtp.c:3817
+#: src/msmtp.c:3969
 #, c-format
 msgid "account chosen by envelope from address %s: %s\n"
 msgstr "налог који је изабран адресом за „коверту шаље“ „%s“: %s\n"
 
-#: src/msmtp.c:3831
+#: src/msmtp.c:3983
 #, c-format
 msgid "falling back to default account\n"
 msgstr "пребацујем се на основни налог\n"
 
-#: src/msmtp.c:3854
+#: src/msmtp.c:4006
 #, c-format
 msgid "using environment variables EMAIL and SMTPSERVER\n"
 msgstr "користим променљиве окружења „EMAIL“ и „SMTPSERVER“\n"
 
-#: src/msmtp.c:3862
+#: src/msmtp.c:4014
 #, c-format
 msgid "account %s not found in %s and %s"
 msgstr "нисам нашао налог „%s“ у „%s“ и „%s“"
 
-#: src/msmtp.c:3868 src/msmtp.c:3873
+#: src/msmtp.c:4020 src/msmtp.c:4025
 #, c-format
 msgid "account %s not found in %s"
 msgstr "нисам нашао налог „%s“ у „%s“"
 
-#: src/msmtp.c:3878
+#: src/msmtp.c:4030
 #, c-format
 msgid "account %s not found: no configuration file available"
 msgstr "нисам нашао налог „%s“: датотека подешавања није доступна"
 
-#: src/msmtp.c:3893
+#: src/msmtp.c:4045
 #, c-format
 msgid "using account specified on command line\n"
 msgstr "користим налог наведен на линији наредби\n"
 
-#: src/msmtp.c:3959
+#: src/msmtp.c:4110
 #, c-format
 msgid "account %s from %s: %s"
 msgstr "налог „%s“ из „%s“: %s"
 
-#: src/msmtp.c:4000
+#: src/msmtp.c:4151
 msgid "this platform does not support syslog logging"
 msgstr "ова платформа не подржава вођење системског дневника"
 
-#: src/msmtp.c:4009
+#: src/msmtp.c:4160
 #, c-format
 msgid "support for authentication method %s is not compiled in"
 msgstr "подршка за начин потврђивања идентитета „%s“ није преведена"
 
-#: src/msmtp.c:4017
+#: src/msmtp.c:4168
 #, c-format
 msgid "cannot initialize networking: %s"
 msgstr "не могу да покренем умрежавање: %s"
 
-#: src/msmtp.c:4028
+#: src/msmtp.c:4179
 #, c-format
 msgid "cannot initialize TLS library: %s"
 msgstr "не могу да покренем „TLS“ библиотеку: %s"
 
-#: src/msmtp.c:4035
+#: src/msmtp.c:4186
 msgid "support for TLS is not compiled in"
 msgstr "подршка за „TLS“ није преведена"
 
-#: src/msmtp.c:4114
+#: src/msmtp.c:4272
 #, c-format
 msgid "LMTP server message: %s"
 msgstr "порука „LMTP“ сервера: %s"
 
-#: src/msmtp.c:4125
+#: src/msmtp.c:4283
 #, c-format
 msgid "could not send mail to all recipients (account %s from %s)"
 msgstr "не могу да пошаљем пошту свим примаоцима (налог „%s“ са „%s“)"
 
-#: src/msmtp.c:4131
+#: src/msmtp.c:4289
 msgid "could not send mail to all recipients"
 msgstr "не могу да пошаљем пошту свим примаоцима"
 
-#: src/msmtp.c:4146 src/msmtp.c:4201 src/msmtp.c:4222
+#: src/msmtp.c:4304 src/msmtp.c:4359 src/msmtp.c:4380
 #, c-format
 msgid "server message: %s"
 msgstr "порука сервера: %s"
 
-#: src/msmtp.c:4152
+#: src/msmtp.c:4310
 #, c-format
 msgid "could not send mail (account %s from %s)"
 msgstr "не могу да пошаљем пошту (налог „%s“ са „%s“)"
 
-#: src/msmtp.c:4157
+#: src/msmtp.c:4315
 msgid "could not send mail"
 msgstr "не могу да пошаљем пошту"
 
-#: src/msmtp.c:4167
+#: src/msmtp.c:4325
 #, c-format
 msgid "delivery to one or more recipients failed"
 msgstr "испорука примаоцу или примаоцима није успела"
@@ -1638,16 +1645,6 @@ msgstr "не могу да се повежем на „%s“, прикључни
 msgid "password for %s at %s: "
 msgstr "лозинка за „%s“ на „%s“: "
 
-#: src/password.c:252
-#, c-format
-msgid "cannot evaluate '%s': %s"
-msgstr "не могу да оценим „%s“: %s"
-
-#: src/password.c:262
-#, c-format
-msgid "cannot read output of '%s'"
-msgstr "не могу да читам излаз од „%s“"
-
 #: src/smtp.c:208
 #, c-format
 msgid "the server sent an empty reply"
@@ -1782,6 +1779,14 @@ msgstr "сервер није у могућности да испуни захт
 #, c-format
 msgid "invalid argument for Remote Message Queue Starting"
 msgstr "неисправан аргумент за започињање реда удаљене поруке"
+
+#, c-format
+#~ msgid "cannot evaluate '%s': %s"
+#~ msgstr "не могу да оценим „%s“: %s"
+
+#, c-format
+#~ msgid "cannot read output of '%s'"
+#~ msgstr "не могу да читам излаз од „%s“"
 
 #~ msgid "Common Name"
 #~ msgstr "Општи назив"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: msmtp 1.8.8rc2\n"
 "Report-Msgid-Bugs-To: marlam@marlam.de\n"
-"POT-Creation-Date: 2022-03-23 20:22+0100\n"
+"POT-Creation-Date: 2022-07-27 18:42+0200\n"
 "PO-Revision-Date: 2020-04-07 18:54+0530\n"
 "Last-Translator: Arun Isaac <arunisaac@systemreboot.net>\n"
 "Language-Team: Tamil <tamil@systemreboot.net>\n"
@@ -38,7 +38,7 @@ msgstr ""
 msgid "line %d: duplicate alias '%s'"
 msgstr ""
 
-#: src/aliases.c:178 src/conf.c:1072 src/stream.c:63
+#: src/aliases.c:178 src/conf.c:1193 src/stream.c:63
 #, c-format
 msgid "input error"
 msgstr "உள்ளீட்டுப் பிழை"
@@ -48,105 +48,105 @@ msgstr "உள்ளீட்டுப் பிழை"
 msgid "Too many redirects when expanding alias %s."
 msgstr ""
 
-#: src/conf.c:808 src/conf.c:823
+#: src/conf.c:815 src/conf.c:830
 #, c-format
 msgid "host not set"
 msgstr ""
 
-#: src/conf.c:813
+#: src/conf.c:820
 #, c-format
 msgid "port not set"
 msgstr "வாயில் குறிப்பிடப்படவில்லை"
 
-#: src/conf.c:818
+#: src/conf.c:825
 #, c-format
 msgid "envelope-from address is missing"
 msgstr ""
 
-#: src/conf.c:828
+#: src/conf.c:835
 #, c-format
 msgid "tls_key_file requires tls_cert_file"
 msgstr "tls_key_file க்கு tls_cert_file தேவை"
 
-#: src/conf.c:833
+#: src/conf.c:840
 #, c-format
 msgid "tls_cert_file requires tls_key_file"
 msgstr "tls_cert_file க்கு tls_key_file தேவை"
 
-#: src/conf.c:841
+#: src/conf.c:848
 #, c-format
 msgid ""
 "tls requires either tls_trust_file (highly recommended) or tls_fingerprint "
 "or a disabled tls_certcheck"
 msgstr ""
 
-#: src/conf.c:847
+#: src/conf.c:854
 #, c-format
 msgid "tls_crl_file requires tls_trust_file"
 msgstr "tls_crl_file க்கு tls_trust_file தேவை"
 
-#: src/conf.c:879 src/conf.c:886 src/conf.c:903 src/mtls-gnutls.c:328
+#: src/conf.c:886 src/conf.c:893 src/conf.c:910 src/mtls-gnutls.c:328
 #, c-format
 msgid "%s: %s"
 msgstr "%s: %s"
 
-#: src/conf.c:1094
-#, c-format
-msgid "line longer than %d characters"
-msgstr "வரியில் %d வரியுருகளுக்கு அதிமாக உள்ளன"
-
-#: src/conf.c:1145 src/conf.c:1270
+#: src/conf.c:1119 src/conf.c:1292
 #, c-format
 msgid "line %d: missing account name"
 msgstr "வரி %d: கணக்குப் பெயர் இல்லை"
 
-#: src/conf.c:1150
+#: src/conf.c:1124
 #, c-format
 msgid "line %d: account %s not (yet) defined"
 msgstr ""
 
-#: src/conf.c:1242 src/conf.c:2060 src/conf.c:2077
+#: src/conf.c:1205
 #, c-format
-msgid "line %d: command %s does not take an argument"
-msgstr "வரி %d: %s கட்டளைக்குச் செயலுருபு கிடையாது"
+msgid "line longer than %d characters"
+msgstr "வரியில் %d வரியுருகளுக்கு அதிமாக உள்ளன"
 
-#: src/conf.c:1278
-#, c-format
-msgid "line %d: an account name must not contain colons or commas"
-msgstr "வரி %d: கணக்குப் பெயரில் விளக்கிசைக்குறிகளோ உறுப்பிசைக்குறிகளோ இடம்பெறக்கூடாது"
-
-#: src/conf.c:1288
-#, c-format
-msgid "line %d: account %s was already defined"
-msgstr "வரி %d: %s என்னும் கணக்கு ஏற்கனவே வரையறுக்கப்பட்டது"
-
-#: src/conf.c:1313 src/conf.c:1332 src/conf.c:1359 src/conf.c:1388
-#: src/conf.c:1695 src/conf.c:1730
+#: src/conf.c:1222 src/conf.c:1335 src/conf.c:1354 src/conf.c:1381
+#: src/conf.c:1410 src/conf.c:1718 src/conf.c:1753
 #, c-format
 msgid "line %d: command %s needs an argument"
 msgstr "வரி %d: %s கட்டளைக்குச் செயலுருபு தேவை"
 
-#: src/conf.c:1343 src/conf.c:1375 src/conf.c:1406 src/conf.c:1440
-#: src/conf.c:1466 src/conf.c:1511 src/conf.c:1531 src/conf.c:1616
-#: src/conf.c:1637 src/conf.c:1656 src/conf.c:1717 src/conf.c:1748
-#: src/conf.c:1798 src/conf.c:1845 src/conf.c:1870 src/conf.c:1890
-#: src/conf.c:1910 src/conf.c:1930 src/conf.c:1977 src/conf.c:1998
-#: src/conf.c:2019 src/conf.c:2047
+#: src/conf.c:1264 src/conf.c:2103 src/conf.c:2120
+#, c-format
+msgid "line %d: command %s does not take an argument"
+msgstr "வரி %d: %s கட்டளைக்குச் செயலுருபு கிடையாது"
+
+#: src/conf.c:1300
+#, c-format
+msgid "line %d: an account name must not contain colons or commas"
+msgstr "வரி %d: கணக்குப் பெயரில் விளக்கிசைக்குறிகளோ உறுப்பிசைக்குறிகளோ இடம்பெறக்கூடாது"
+
+#: src/conf.c:1310
+#, c-format
+msgid "line %d: account %s was already defined"
+msgstr "வரி %d: %s என்னும் கணக்கு ஏற்கனவே வரையறுக்கப்பட்டது"
+
+#: src/conf.c:1365 src/conf.c:1397 src/conf.c:1428 src/conf.c:1462
+#: src/conf.c:1488 src/conf.c:1534 src/conf.c:1554 src/conf.c:1639
+#: src/conf.c:1660 src/conf.c:1679 src/conf.c:1740 src/conf.c:1771
+#: src/conf.c:1821 src/conf.c:1868 src/conf.c:1893 src/conf.c:1913
+#: src/conf.c:1933 src/conf.c:1953 src/conf.c:1973 src/conf.c:2020
+#: src/conf.c:2041 src/conf.c:2062 src/conf.c:2090
 #, c-format
 msgid "line %d: invalid argument %s for command %s"
 msgstr ""
 
-#: src/conf.c:2093
+#: src/conf.c:2136
 #, c-format
 msgid "line %d: unknown command %s"
 msgstr "வரி %d: அறியப்படாக் கட்டளை %s"
 
-#: src/conf.c:2145
+#: src/conf.c:2190
 #, c-format
 msgid "contains secrets and therefore must be owned by you"
 msgstr ""
 
-#: src/conf.c:2151
+#: src/conf.c:2196
 #, c-format
 msgid ""
 "contains secrets and therefore must have no more than user read/write "
@@ -155,276 +155,276 @@ msgstr ""
 
 #. TRANSLATORS: msmtp shares a lot of code and translatable strings with
 #. mpop <https://marlam.de/mpop>.
-#: src/msmtp.c:88
+#: src/msmtp.c:90
 #, c-format
 msgid "%s: FATAL: %s\n"
 msgstr "%s: முறிவுப்பிழை: %s\n"
 
-#: src/msmtp.c:228 src/msmtp.c:406 src/msmtp.c:1401
+#: src/msmtp.c:230 src/msmtp.c:408 src/msmtp.c:1522
 #, c-format
 msgid "the server does not support TLS via the STARTTLS command"
 msgstr ""
 
-#: src/msmtp.c:270
+#: src/msmtp.c:272
 #, c-format
 msgid "the server does not support Remote Message Queue Starting"
 msgstr ""
 
-#: src/msmtp.c:282 src/msmtp.c:1459
+#: src/msmtp.c:284 src/msmtp.c:1580
 #, c-format
 msgid "the server does not support authentication"
 msgstr ""
 
-#: src/msmtp.c:441
+#: src/msmtp.c:443
 #, c-format
 msgid "%s server at %s (%s [%s]), port %d:\n"
 msgstr "%2$s (%3$s [%4$s]) வாயில் %5$d யிலுள்ள %1$s வழங்கி\n"
 
-#: src/msmtp.c:447
+#: src/msmtp.c:450
 #, c-format
 msgid "%s server at %s (%s), port %d:\n"
 msgstr "%2$s (%3$s) வாயில் %4$d யிலுள்ள %1$s வழங்கி\n"
 
-#: src/msmtp.c:453
+#: src/msmtp.c:457
 #, c-format
 msgid "%s server at %s ([%s]), port %d:\n"
 msgstr "%2$s ([%3$s]) வாயில் %4$d யிலுள்ள %1$s வழங்கி\n"
 
-#: src/msmtp.c:459
+#: src/msmtp.c:464
 #, c-format
 msgid "%s server at %s, port %d:\n"
 msgstr "%2$s வாயில் %3$d யிலுள்ள %1$s வழங்கி\n"
 
-#: src/msmtp.c:479
+#: src/msmtp.c:485
 #, c-format
 msgid "No special capabilities.\n"
 msgstr "சிறப்புச் செயல்வல்லமைகள் எதுவுமில்லை.\n"
 
-#: src/msmtp.c:483
+#: src/msmtp.c:489
 #, c-format
 msgid "Capabilities:\n"
 msgstr "செயல்வல்லமைகள்:\n"
 
-#: src/msmtp.c:487
+#: src/msmtp.c:493
 msgid "Maximum message size is "
 msgstr ""
 
-#: src/msmtp.c:490
+#: src/msmtp.c:496
 #, c-format
 msgid "unlimited\n"
 msgstr ""
 
-#: src/msmtp.c:494
+#: src/msmtp.c:500
 #, c-format
 msgid "%ld bytes"
 msgstr "%ld எண்ணுண்மிகள்"
 
-#: src/msmtp.c:497
+#: src/msmtp.c:503
 #, c-format
 msgid " = %.2f MiB"
 msgstr " = %.2f MiB"
 
-#: src/msmtp.c:502
+#: src/msmtp.c:508
 #, c-format
 msgid " = %.2f KiB"
 msgstr " = %.2f KiB"
 
-#: src/msmtp.c:509
+#: src/msmtp.c:515
 msgid "Support for command grouping for faster transmission"
 msgstr ""
 
-#: src/msmtp.c:514
+#: src/msmtp.c:520
 msgid "Support for RMQS (Remote Message Queue Starting)"
 msgstr ""
 
-#: src/msmtp.c:519
+#: src/msmtp.c:525
 msgid "Support for Delivery Status Notifications"
 msgstr ""
 
-#: src/msmtp.c:529
+#: src/msmtp.c:535
 msgid "Support for TLS encryption via the STARTTLS command"
 msgstr ""
 
-#: src/msmtp.c:535
+#: src/msmtp.c:541
 msgid "Supported authentication methods:"
 msgstr ""
 
-#: src/msmtp.c:588
+#: src/msmtp.c:594
 #, c-format
 msgid ""
 "This server might advertise more or other capabilities when TLS is active.\n"
 msgstr "இவ்வழங்கி TLS இருந்தால் பிறச் செயல்வல்லமைகளை வெளிப்படுத்தலாம்.\n"
 
-#: src/msmtp.c:1153 src/msmtp.c:3299
+#: src/msmtp.c:1274 src/msmtp.c:3447
 #, c-format
 msgid "cannot write mail headers to temporary file: output error"
 msgstr ""
 
-#: src/msmtp.c:1261
+#: src/msmtp.c:1382
 #, c-format
 msgid "input error while reading the mail"
 msgstr ""
 
-#: src/msmtp.c:1448
+#: src/msmtp.c:1569
 #, c-format
 msgid "the server does not support DSN"
 msgstr ""
 
-#: src/msmtp.c:1597 src/msmtp.c:1616 src/msmtp.c:1668
+#: src/msmtp.c:1718 src/msmtp.c:1737 src/msmtp.c:1789
 #, c-format
 msgid "automatic configuration based on SRV records failed: %s"
 msgstr ""
 
-#: src/msmtp.c:1598
+#: src/msmtp.c:1719
 msgid "invalid mail address"
 msgstr "ஏற்கத்தகா அஞ்சல் முகவரி"
 
-#: src/msmtp.c:1614
+#: src/msmtp.c:1735
 #, c-format
 msgid "no SRV records for %s or %s"
 msgstr ""
 
-#: src/msmtp.c:1631
+#: src/msmtp.c:1752
 #, c-format
 msgid "copy this to your configuration file %s"
 msgstr ""
 
-#: src/msmtp.c:1635
+#: src/msmtp.c:1756
 msgid "warning: the host does not match the mail domain; please check"
 msgstr ""
 
-#: src/msmtp.c:1638 src/msmtp.c:1642
+#: src/msmtp.c:1759 src/msmtp.c:1763
 msgid "add your password to the key ring:"
 msgstr ""
 
-#: src/msmtp.c:1645
+#: src/msmtp.c:1766
 msgid "encrypt your password:"
 msgstr ""
 
-#: src/msmtp.c:1669
+#: src/msmtp.c:1790
 msgid "this system lacks libresolv"
 msgstr ""
 
-#: src/msmtp.c:1896
+#: src/msmtp.c:2022
 #, c-format
 msgid "invalid logfile_time_format"
 msgstr ""
 
-#: src/msmtp.c:1909
+#: src/msmtp.c:2035
 #, c-format
 msgid "cannot open: %s"
 msgstr "திறக்க இயலவில்லை: %s"
 
-#: src/msmtp.c:1917
+#: src/msmtp.c:2043
 #, c-format
 msgid "cannot lock (tried for %d seconds): %s"
 msgstr "பூட்ட இயலவில்லை (%d நொடிகளுக்கு முயலப்பட்டது): %s"
 
-#: src/msmtp.c:1922
+#: src/msmtp.c:2048
 #, c-format
 msgid "cannot lock: %s"
 msgstr "பூட்ட இயலவில்லை: %s"
 
-#: src/msmtp.c:1931
+#: src/msmtp.c:2057
 msgid "output error"
 msgstr "வெளியீட்டுப் பிழை"
 
-#: src/msmtp.c:1948
+#: src/msmtp.c:2074
 #, c-format
 msgid "cannot log to %s: %s"
 msgstr "%s யில் குறிக்க இயலவில்லை: %s"
 
-#: src/msmtp.c:1952
+#: src/msmtp.c:2078
 #, c-format
 msgid "log info was: %s"
 msgstr ""
 
-#: src/msmtp.c:2061
+#: src/msmtp.c:2187
 #, c-format
 msgid "%s version %s\n"
 msgstr "%s பதிப்பெண் %s\n"
 
-#: src/msmtp.c:2062
+#: src/msmtp.c:2188
 #, c-format
 msgid "Platform: %s\n"
 msgstr "இயங்குதளம்: %s\n"
 
-#: src/msmtp.c:2064
+#: src/msmtp.c:2190
 #, c-format
 msgid "TLS/SSL library: %s\n"
 msgstr "TLS/SSL நிரலகம்: %s\n"
 
-#: src/msmtp.c:2072 src/msmtp.c:2150
+#: src/msmtp.c:2198 src/msmtp.c:2276
 #, c-format
 msgid "none"
 msgstr "இல்லை"
 
-#: src/msmtp.c:2076
+#: src/msmtp.c:2202
 #, c-format
 msgid ""
 "Authentication library: %s\n"
 "Supported authentication methods:\n"
 msgstr ""
 
-#: src/msmtp.c:2079
+#: src/msmtp.c:2205
 msgid "GNU SASL; oauthbearer and xoauth2: built-in"
 msgstr ""
 
-#: src/msmtp.c:2081
+#: src/msmtp.c:2207
 msgid "built-in"
 msgstr ""
 
-#: src/msmtp.c:2130
+#: src/msmtp.c:2256
 #, c-format
 msgid "IDN support: "
 msgstr ""
 
-#: src/msmtp.c:2134 src/msmtp.c:2142
+#: src/msmtp.c:2260 src/msmtp.c:2268
 #, c-format
 msgid "enabled"
 msgstr ""
 
-#: src/msmtp.c:2136 src/msmtp.c:2145
+#: src/msmtp.c:2262 src/msmtp.c:2271
 #, c-format
 msgid "disabled"
 msgstr ""
 
-#: src/msmtp.c:2140
+#: src/msmtp.c:2266
 #, c-format
 msgid "NLS: "
 msgstr ""
 
-#: src/msmtp.c:2143
+#: src/msmtp.c:2269
 #, c-format
 msgid ", LOCALEDIR is %s"
 msgstr ""
 
-#: src/msmtp.c:2148
+#: src/msmtp.c:2274
 #, c-format
 msgid "Keyring support: "
 msgstr ""
 
-#: src/msmtp.c:2153
+#: src/msmtp.c:2279
 #, c-format
 msgid "Gnome "
 msgstr ""
 
-#: src/msmtp.c:2156
+#: src/msmtp.c:2282
 #, c-format
 msgid "MacOS "
 msgstr ""
 
-#: src/msmtp.c:2162
+#: src/msmtp.c:2288
 #, c-format
 msgid "System configuration file name: %s\n"
 msgstr "பொது அமைவடிவக்கோப்பு: %s\n"
 
-#: src/msmtp.c:2166
+#: src/msmtp.c:2292
 #, c-format
 msgid "User configuration file name: %s\n"
 msgstr "பயனர் அமைவடிவக்கோப்பு: %s\n"
 
-#: src/msmtp.c:2169
+#: src/msmtp.c:2295
 #, fuzzy, c-format
 #| msgid ""
 #| "Copyright (C) 2020 Martin Lambers and others.\n"
@@ -444,7 +444,7 @@ msgstr ""
 "<http://gnu.org/licenses/gpl.html> என்னும் உரிமத்தின் கீழ் மறுவிநியோகம் செய்யலாம்.\n"
 "சட்டத்தால் அனுமதிக்கப்பட்ட அளவிற்கு எந்த உத்தரவாதமும் இல்லை.\n"
 
-#: src/msmtp.c:2186
+#: src/msmtp.c:2312
 #, c-format
 msgid ""
 "Usage:\n"
@@ -453,7 +453,7 @@ msgstr ""
 "பயன்பாடு:\n"
 "\n"
 
-#: src/msmtp.c:2187
+#: src/msmtp.c:2313
 #, c-format
 msgid ""
 "Sendmail mode (default):\n"
@@ -463,7 +463,7 @@ msgid ""
 "server.\n"
 msgstr ""
 
-#: src/msmtp.c:2192
+#: src/msmtp.c:2318
 #, c-format
 msgid ""
 "Configuration mode:\n"
@@ -471,7 +471,7 @@ msgid ""
 "  Generate and print configuration for address.\n"
 msgstr ""
 
-#: src/msmtp.c:2195
+#: src/msmtp.c:2321
 #, c-format
 msgid ""
 "Server information mode:\n"
@@ -482,7 +482,7 @@ msgstr ""
 "  %s [செயல்மாற்றி...] --serverinfo\n"
 "  வழங்கி விவரத்தைக் காட்டு\n"
 
-#: src/msmtp.c:2198
+#: src/msmtp.c:2324
 #, c-format
 msgid ""
 "Remote Message Queue Starting mode:\n"
@@ -491,64 +491,64 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/msmtp.c:2202
+#: src/msmtp.c:2328
 #, c-format
 msgid "General options:\n"
 msgstr "பொதுவான செயல்மாற்றிகள்:\n"
 
-#: src/msmtp.c:2203
+#: src/msmtp.c:2329
 #, c-format
 msgid "  --version                    print version\n"
 msgstr "  --version                   பதிப்பு விவரத்தைக் காட்டு\n"
 
-#: src/msmtp.c:2204
+#: src/msmtp.c:2330
 #, c-format
 msgid "  --help                       print help\n"
 msgstr "  --help                      உதவிச் செய்தியைக் காட்டு\n"
 
-#: src/msmtp.c:2205
+#: src/msmtp.c:2331
 #, c-format
 msgid "  -P, --pretend                print configuration info and exit\n"
 msgstr "  -P, --pretend               அமைவடிவ விவரத்தைக் காட்டி வெளியேறு\n"
 
-#: src/msmtp.c:2206
+#: src/msmtp.c:2332
 #, c-format
 msgid "  -d, --debug                  print debugging information\n"
 msgstr ""
 
-#: src/msmtp.c:2207
+#: src/msmtp.c:2333
 #, c-format
 msgid "Changing the mode of operation:\n"
 msgstr "செய்பணி பாங்கை மாற்றுவது:\n"
 
-#: src/msmtp.c:2208
+#: src/msmtp.c:2334
 #, c-format
 msgid ""
 "  --configure=mailaddress      generate and print configuration for address\n"
 msgstr ""
 
-#: src/msmtp.c:2209
+#: src/msmtp.c:2335
 #, c-format
 msgid "  -S, --serverinfo             print information about the server\n"
 msgstr "  -S, --serverinfo            வழங்கி விவரத்தைக் காட்டு\n"
 
-#: src/msmtp.c:2210
+#: src/msmtp.c:2336
 #, c-format
 msgid ""
 "  --rmqs=host|@domain|#queue   send a Remote Message Queue Starting request\n"
 msgstr ""
 
-#: src/msmtp.c:2211
+#: src/msmtp.c:2337
 #, c-format
 msgid "Configuration options:\n"
 msgstr "அமைவடிவ செயல்மாற்றிகள்:\n"
 
-#: src/msmtp.c:2212
+#: src/msmtp.c:2338
 #, c-format
 msgid "  -C, --file=filename          set configuration file\n"
 msgstr "  -C, --file=கோப்புப்பெயர்      அமைவடிவக்கோப்பைக் குறிப்பிடு\n"
 
-#: src/msmtp.c:2213
+#: src/msmtp.c:2339
 #, c-format
 msgid ""
 "  -a, --account=id             use the given account instead of the account\n"
@@ -557,7 +557,7 @@ msgid ""
 "                               with command-line options\n"
 msgstr ""
 
-#: src/msmtp.c:2216
+#: src/msmtp.c:2342
 #, c-format
 msgid ""
 "  --host=hostname              set the server, use only command-line "
@@ -565,213 +565,218 @@ msgid ""
 "                               do not use any configuration file data\n"
 msgstr ""
 
-#: src/msmtp.c:2218
+#: src/msmtp.c:2344
 #, c-format
 msgid "  --port=number                set port number\n"
 msgstr "  --port=எண்                 வாயில் எண்ணைக் குறிப்பிடு\n"
 
-#: src/msmtp.c:2219
+#: src/msmtp.c:2345
 #, c-format
 msgid ""
 "  --source-ip=[IP]             set/unset source ip address to bind the "
 "socket to\n"
 msgstr ""
 
-#: src/msmtp.c:2220
+#: src/msmtp.c:2346
 #, c-format
 msgid "  --proxy-host=[IP|hostname]   set/unset proxy\n"
 msgstr ""
 
-#: src/msmtp.c:2221
+#: src/msmtp.c:2347
 #, c-format
 msgid "  --proxy-port=[number]        set/unset proxy port\n"
 msgstr ""
 
-#: src/msmtp.c:2222
+#: src/msmtp.c:2348
 #, c-format
 msgid "  --socket=[socketname]        set/unset local socket to connect to\n"
 msgstr ""
 
-#: src/msmtp.c:2223
+#: src/msmtp.c:2349
 #, c-format
 msgid "  --timeout=(off|seconds)      set/unset network timeout in seconds\n"
 msgstr ""
 
-#: src/msmtp.c:2224
+#: src/msmtp.c:2350
 #, c-format
 msgid "  --protocol=(smtp|lmtp)       use the given sub protocol\n"
 msgstr ""
 
-#: src/msmtp.c:2225
+#: src/msmtp.c:2351
 #, c-format
 msgid ""
 "  --domain=string              set the argument of EHLO or LHLO command\n"
 msgstr ""
 
-#: src/msmtp.c:2226
+#: src/msmtp.c:2352
 #, c-format
 msgid ""
 "  --auth[=(on|off|method)]     enable/disable authentication and optionally\n"
 "                               choose the method\n"
 msgstr ""
 
-#: src/msmtp.c:2228
+#: src/msmtp.c:2354
 #, c-format
 msgid "  --user=[username]            set/unset user name for authentication\n"
 msgstr ""
 
-#: src/msmtp.c:2229
+#: src/msmtp.c:2355
 #, c-format
 msgid "  --passwordeval=[eval]        evaluate password for authentication\n"
 msgstr ""
 
-#: src/msmtp.c:2230
+#: src/msmtp.c:2356
 #, c-format
 msgid "  --tls[=(on|off)]             enable/disable TLS encryption\n"
 msgstr ""
 
-#: src/msmtp.c:2231
+#: src/msmtp.c:2357
 #, c-format
 msgid "  --tls-starttls[=(on|off)]    enable/disable STARTTLS for TLS\n"
 msgstr ""
 
-#: src/msmtp.c:2232
+#: src/msmtp.c:2358
 #, c-format
 msgid "  --tls-trust-file=[file]      set/unset trust file for TLS\n"
 msgstr ""
 
-#: src/msmtp.c:2233
+#: src/msmtp.c:2359
 #, c-format
 msgid "  --tls-crl-file=[file]        set/unset revocation file for TLS\n"
 msgstr ""
 
-#: src/msmtp.c:2234
+#: src/msmtp.c:2360
 #, c-format
 msgid ""
 "  --tls-fingerprint=[f]        set/unset trusted certificate fingerprint for "
 "TLS\n"
 msgstr ""
 
-#: src/msmtp.c:2235
+#: src/msmtp.c:2361
 #, c-format
 msgid ""
 "  --tls-certcheck[=(on|off)]   enable/disable server certificate checks for "
 "TLS\n"
 msgstr ""
 
-#: src/msmtp.c:2236
+#: src/msmtp.c:2362
 #, c-format
 msgid "  --tls-key-file=[file]        set/unset private key file for TLS\n"
 msgstr ""
 
-#: src/msmtp.c:2237
+#: src/msmtp.c:2363
 #, c-format
 msgid "  --tls-cert-file=[file]       set/unset private cert file for TLS\n"
 msgstr ""
 
-#: src/msmtp.c:2238
+#: src/msmtp.c:2364
 #, c-format
 msgid "  --tls-priorities=[prios]     set/unset TLS priorities.\n"
 msgstr ""
 
-#: src/msmtp.c:2239
+#: src/msmtp.c:2365
 #, c-format
 msgid ""
 "  --tls-host-override=[host]   set/unset override for TLS host "
 "verification.\n"
 msgstr ""
 
-#: src/msmtp.c:2240
+#: src/msmtp.c:2366
 #, c-format
 msgid "  --tls-min-dh-prime-bits=[b]  set/unset minimum bit size of DH prime\n"
 msgstr ""
 
-#: src/msmtp.c:2241
+#: src/msmtp.c:2367
 #, c-format
 msgid "Options specific to sendmail mode:\n"
 msgstr ""
 
-#: src/msmtp.c:2242
+#: src/msmtp.c:2368
 #, c-format
 msgid ""
 "  --auto-from[=(on|off)]       enable/disable automatic envelope-from "
 "addresses\n"
 msgstr ""
 
-#: src/msmtp.c:2243
+#: src/msmtp.c:2369
 #, c-format
 msgid "  -f, --from=address           set envelope from address\n"
 msgstr ""
 
-#: src/msmtp.c:2244
+#: src/msmtp.c:2370
 #, c-format
 msgid ""
 "  --maildomain=[domain]        set the domain for automatic envelope from\n"
 "                               addresses\n"
 msgstr ""
 
-#: src/msmtp.c:2246
+#: src/msmtp.c:2372
 #, c-format
 msgid "  -N, --dsn-notify=(off|cond)  set/unset DSN conditions\n"
 msgstr ""
 
-#: src/msmtp.c:2247
+#: src/msmtp.c:2373
 #, c-format
 msgid "  -R, --dsn-return=(off|ret)   set/unset DSN amount\n"
 msgstr ""
 
-#: src/msmtp.c:2248
+#: src/msmtp.c:2374
 #, c-format
 msgid "  -X, --logfile=[file]         set/unset log file\n"
 msgstr "  -X, --logfile=கோப்பு         குறிப்பேடைக் குறிப்பிடு\n"
 
-#: src/msmtp.c:2249
+#: src/msmtp.c:2375
 #, c-format
 msgid ""
 "  --logfile-time-format=[fmt]  set/unset log file time format for "
 "strftime()\n"
 msgstr ""
 
-#: src/msmtp.c:2250
+#: src/msmtp.c:2376
 #, c-format
 msgid ""
 "  --syslog[=(on|off|facility)] enable/disable/configure syslog logging\n"
 msgstr ""
 
-#: src/msmtp.c:2251
+#: src/msmtp.c:2377
 #, c-format
 msgid ""
 "  -t, --read-recipients        read additional recipients from the mail\n"
 msgstr ""
 
-#: src/msmtp.c:2252
+#: src/msmtp.c:2378
 #, c-format
 msgid ""
 "  --read-envelope-from         read envelope from address from the mail\n"
 msgstr ""
 
-#: src/msmtp.c:2253
+#: src/msmtp.c:2379
 #, c-format
 msgid "  --aliases=[file]             set/unset aliases file\n"
 msgstr ""
 
-#: src/msmtp.c:2254
+#: src/msmtp.c:2380
 #, c-format
 msgid "  --set-from-header[=(auto|on|off)] set From header handling\n"
 msgstr ""
 
-#: src/msmtp.c:2255
+#: src/msmtp.c:2381
 #, c-format
 msgid "  --set-date-header[=(auto|off)] set Date header handling\n"
 msgstr ""
 
-#: src/msmtp.c:2256
+#: src/msmtp.c:2382
+#, c-format
+msgid "  --set-msgid-header[=(auto|off)] set Message-ID header handling\n"
+msgstr ""
+
+#: src/msmtp.c:2383
 #, c-format
 msgid ""
 "  --remove-bcc-headers[=(on|off)] enable/disable removal of Bcc headers\n"
 msgstr ""
 
-#: src/msmtp.c:2257
+#: src/msmtp.c:2384
 #, c-format
 msgid ""
 "  --undisclosed-recipients[=(on|off)] enable/disable replacement of To/Cc/"
@@ -779,18 +784,18 @@ msgid ""
 "                               with To: undisclosed-recipients:;\n"
 msgstr ""
 
-#: src/msmtp.c:2259
+#: src/msmtp.c:2386
 #, c-format
 msgid "  --                           end of options\n"
 msgstr "  --                          செயல்மாற்றிகளின் முடிவு\n"
 
-#: src/msmtp.c:2260
+#: src/msmtp.c:2387
 #, c-format
 msgid ""
 "Accepted but ignored: -A, -B, -bm, -F, -G, -h, -i, -L, -m, -n, -O, -o, -v\n"
 msgstr ""
 
-#: src/msmtp.c:2261
+#: src/msmtp.c:2388
 #, c-format
 msgid ""
 "\n"
@@ -801,235 +806,235 @@ msgstr ""
 "வழுக்களை <%s> யிடம் தெரிவிக்க.\n"
 "தமிழாக்க வழுக்களை <tamil@systemreboot.net> யிடம் தெரிவிக்க.\n"
 
-#: src/msmtp.c:2503 src/msmtp.c:2517
+#: src/msmtp.c:2633 src/msmtp.c:2647
 msgid "cannot use both --serverinfo and --rmqs"
 msgstr "--serverinfo, --rmqs இரண்டையும் ஒரே நேரத்தில் குறிப்பிடக்கூடாது"
 
-#: src/msmtp.c:2537 src/msmtp.c:2549
+#: src/msmtp.c:2667 src/msmtp.c:2679
 msgid "cannot use both --host and --account"
 msgstr "--host, --account இரண்டையும் ஒரே நேரத்தில் குறிப்பிடக்கூடாது"
 
-#: src/msmtp.c:2565 src/msmtp.c:2583 src/msmtp.c:2602 src/msmtp.c:2657
-#: src/msmtp.c:2689 src/msmtp.c:2707 src/msmtp.c:2770 src/msmtp.c:2815
-#: src/msmtp.c:2837 src/msmtp.c:2883 src/msmtp.c:2908 src/msmtp.c:2927
-#: src/msmtp.c:2980 src/msmtp.c:3025 src/msmtp.c:3052 src/msmtp.c:3070
-#: src/msmtp.c:3089 src/msmtp.c:3108 src/msmtp.c:3126 src/msmtp.c:3144
-#: src/msmtp.c:3221
+#: src/msmtp.c:2695 src/msmtp.c:2713 src/msmtp.c:2732 src/msmtp.c:2787
+#: src/msmtp.c:2819 src/msmtp.c:2837 src/msmtp.c:2900 src/msmtp.c:2945
+#: src/msmtp.c:2967 src/msmtp.c:3013 src/msmtp.c:3038 src/msmtp.c:3057
+#: src/msmtp.c:3110 src/msmtp.c:3155 src/msmtp.c:3182 src/msmtp.c:3200
+#: src/msmtp.c:3218 src/msmtp.c:3237 src/msmtp.c:3256 src/msmtp.c:3274
+#: src/msmtp.c:3292 src/msmtp.c:3369
 #, c-format
 msgid "invalid argument %s for %s"
 msgstr ""
 
-#: src/msmtp.c:2612 src/msmtp.c:3184
+#: src/msmtp.c:2742 src/msmtp.c:3332
 msgid "cannot use both --from and --read-envelope-from"
 msgstr "--host, --read-envelope-from இரண்டையும் ஒரே நேரத்தில் குறிப்பிடக்கூடாது"
 
-#: src/msmtp.c:3199
+#: src/msmtp.c:3347
 #, c-format
 msgid "unsupported operation mode b%s"
 msgstr ""
 
-#: src/msmtp.c:3276 src/msmtp.c:3753 src/msmtp.c:4052
+#: src/msmtp.c:3424 src/msmtp.c:3904 src/msmtp.c:4204
 #, c-format
 msgid "cannot create temporary file: %s"
 msgstr "தற்காலிகக் கோப்பை உருவாக்க இயலவில்லை: %s"
 
-#: src/msmtp.c:3306 src/msmtp.c:3778 src/msmtp.c:4085
+#: src/msmtp.c:3454 src/msmtp.c:3930 src/msmtp.c:4243
 #, c-format
 msgid "cannot rewind temporary file: %s"
 msgstr ""
 
-#: src/msmtp.c:3371
+#: src/msmtp.c:3520
 #, c-format
 msgid "ignoring system configuration file %s: %s\n"
 msgstr "பொது அமைவடிவக்கொப்பு %s ஒதுக்கப்படுகிறது: %s\n"
 
-#: src/msmtp.c:3386
+#: src/msmtp.c:3535
 #, c-format
 msgid "loaded system configuration file %s\n"
 msgstr "பொது அமைவடிவக்கோப்பு %s ஏற்றப்படுகிறது\n"
 
-#: src/msmtp.c:3425
+#: src/msmtp.c:3574
 #, c-format
 msgid "ignoring user configuration file %s: %s\n"
 msgstr "பயனர் அமைவடிவக்கோப்பு %s ஒதுக்கப்படுகிறது: %s\n"
 
-#: src/msmtp.c:3440
+#: src/msmtp.c:3589
 #, c-format
 msgid "loaded user configuration file %s\n"
 msgstr "பயனர் அமைவடிவக்கோப்பு %s ஏற்றப்படுகிறது\n"
 
-#: src/msmtp.c:3497
+#: src/msmtp.c:3646
 #, c-format
 msgid "using account %s from %s\n"
 msgstr ""
 
-#: src/msmtp.c:3503 src/msmtp.c:3505 src/msmtp.c:3508 src/msmtp.c:3542
-#: src/msmtp.c:3543 src/msmtp.c:3545 src/msmtp.c:3547 src/msmtp.c:3551
-#: src/msmtp.c:3553 src/msmtp.c:3572 src/msmtp.c:3574 src/msmtp.c:3576
-#: src/msmtp.c:3586 src/msmtp.c:3589 src/msmtp.c:3591 src/msmtp.c:3596
-#: src/msmtp.c:3599 src/msmtp.c:3611 src/msmtp.c:3613 src/msmtp.c:3615
-#: src/msmtp.c:3618 src/msmtp.c:3620 src/msmtp.c:3622
+#: src/msmtp.c:3650 src/msmtp.c:3653 src/msmtp.c:3655 src/msmtp.c:3658
+#: src/msmtp.c:3692 src/msmtp.c:3693 src/msmtp.c:3695 src/msmtp.c:3697
+#: src/msmtp.c:3701 src/msmtp.c:3703 src/msmtp.c:3722 src/msmtp.c:3724
+#: src/msmtp.c:3726 src/msmtp.c:3736 src/msmtp.c:3739 src/msmtp.c:3741
+#: src/msmtp.c:3746 src/msmtp.c:3749 src/msmtp.c:3761 src/msmtp.c:3763
+#: src/msmtp.c:3765 src/msmtp.c:3768 src/msmtp.c:3770 src/msmtp.c:3772
 msgid "(not set)"
 msgstr ""
 
-#: src/msmtp.c:3512
+#: src/msmtp.c:3662
 #, c-format
 msgid "off\n"
 msgstr ""
 
-#: src/msmtp.c:3518
+#: src/msmtp.c:3668
 #, c-format
 msgid "%d seconds\n"
 msgstr "%d நொடிகள்\n"
 
-#: src/msmtp.c:3522
+#: src/msmtp.c:3672
 #, c-format
 msgid "1 second\n"
 msgstr "1 நொடி\n"
 
-#: src/msmtp.c:3531
+#: src/msmtp.c:3681
 #, c-format
 msgid "none\n"
 msgstr "இல்லை\n"
 
-#: src/msmtp.c:3535
+#: src/msmtp.c:3685
 #, c-format
 msgid "choose\n"
 msgstr "தேர்ந்தெடு\n"
 
-#: src/msmtp.c:3548 src/msmtp.c:3549 src/msmtp.c:3578 src/msmtp.c:3594
-#: src/msmtp.c:3602 src/msmtp.c:3607 src/msmtp.c:3609
+#: src/msmtp.c:3698 src/msmtp.c:3699 src/msmtp.c:3728 src/msmtp.c:3744
+#: src/msmtp.c:3752 src/msmtp.c:3757 src/msmtp.c:3759
 msgid "on"
 msgstr ""
 
-#: src/msmtp.c:3548 src/msmtp.c:3549 src/msmtp.c:3578 src/msmtp.c:3594
-#: src/msmtp.c:3602 src/msmtp.c:3605 src/msmtp.c:3607 src/msmtp.c:3609
+#: src/msmtp.c:3698 src/msmtp.c:3699 src/msmtp.c:3728 src/msmtp.c:3744
+#: src/msmtp.c:3752 src/msmtp.c:3755 src/msmtp.c:3757 src/msmtp.c:3759
 msgid "off"
 msgstr ""
 
-#: src/msmtp.c:3599
+#: src/msmtp.c:3749
 msgid "(read from mail)"
 msgstr ""
 
-#: src/msmtp.c:3601 src/msmtp.c:3604
+#: src/msmtp.c:3751 src/msmtp.c:3754
 msgid "auto"
 msgstr ""
 
-#: src/msmtp.c:3625
+#: src/msmtp.c:3775
 #, c-format
 msgid "reading recipients from the command line and the mail\n"
 msgstr ""
 
-#: src/msmtp.c:3630
+#: src/msmtp.c:3780
 #, c-format
 msgid "reading recipients from the command line\n"
 msgstr ""
 
-#: src/msmtp.c:3743
+#: src/msmtp.c:3894
 msgid "too many arguments"
 msgstr ""
 
-#: src/msmtp.c:3772
+#: src/msmtp.c:3924
 #, c-format
 msgid "envelope from address extracted from mail: %s\n"
 msgstr ""
 
-#: src/msmtp.c:3787
+#: src/msmtp.c:3939
 msgid "no recipients found"
 msgstr ""
 
-#: src/msmtp.c:3817
+#: src/msmtp.c:3969
 #, c-format
 msgid "account chosen by envelope from address %s: %s\n"
 msgstr ""
 
-#: src/msmtp.c:3831
+#: src/msmtp.c:3983
 #, c-format
 msgid "falling back to default account\n"
 msgstr ""
 
-#: src/msmtp.c:3854
+#: src/msmtp.c:4006
 #, c-format
 msgid "using environment variables EMAIL and SMTPSERVER\n"
 msgstr ""
 
-#: src/msmtp.c:3862
+#: src/msmtp.c:4014
 #, c-format
 msgid "account %s not found in %s and %s"
 msgstr ""
 
-#: src/msmtp.c:3868 src/msmtp.c:3873
+#: src/msmtp.c:4020 src/msmtp.c:4025
 #, c-format
 msgid "account %s not found in %s"
 msgstr ""
 
-#: src/msmtp.c:3878
+#: src/msmtp.c:4030
 #, c-format
 msgid "account %s not found: no configuration file available"
 msgstr ""
 
-#: src/msmtp.c:3893
+#: src/msmtp.c:4045
 #, c-format
 msgid "using account specified on command line\n"
 msgstr ""
 
-#: src/msmtp.c:3959
+#: src/msmtp.c:4110
 #, c-format
 msgid "account %s from %s: %s"
 msgstr ""
 
-#: src/msmtp.c:4000
+#: src/msmtp.c:4151
 msgid "this platform does not support syslog logging"
 msgstr ""
 
-#: src/msmtp.c:4009
+#: src/msmtp.c:4160
 #, c-format
 msgid "support for authentication method %s is not compiled in"
 msgstr ""
 
-#: src/msmtp.c:4017
+#: src/msmtp.c:4168
 #, c-format
 msgid "cannot initialize networking: %s"
 msgstr "வலையத்தைத் தொடங்க இயலவில்லை: %s"
 
-#: src/msmtp.c:4028
+#: src/msmtp.c:4179
 #, c-format
 msgid "cannot initialize TLS library: %s"
 msgstr ""
 
-#: src/msmtp.c:4035
+#: src/msmtp.c:4186
 msgid "support for TLS is not compiled in"
 msgstr ""
 
-#: src/msmtp.c:4114
+#: src/msmtp.c:4272
 #, c-format
 msgid "LMTP server message: %s"
 msgstr "LMTP வழங்கிச் செய்தி: %s"
 
-#: src/msmtp.c:4125
+#: src/msmtp.c:4283
 #, c-format
 msgid "could not send mail to all recipients (account %s from %s)"
 msgstr ""
 
-#: src/msmtp.c:4131
+#: src/msmtp.c:4289
 msgid "could not send mail to all recipients"
 msgstr ""
 
-#: src/msmtp.c:4146 src/msmtp.c:4201 src/msmtp.c:4222
+#: src/msmtp.c:4304 src/msmtp.c:4359 src/msmtp.c:4380
 #, c-format
 msgid "server message: %s"
 msgstr "வழங்கிச் செய்தி: %s"
 
-#: src/msmtp.c:4152
+#: src/msmtp.c:4310
 #, c-format
 msgid "could not send mail (account %s from %s)"
 msgstr "மடல் அனுப்ப இயலவில்லை (%s யிலுள்ள %s கணக்கு)"
 
-#: src/msmtp.c:4157
+#: src/msmtp.c:4315
 msgid "could not send mail"
 msgstr "மடல் அனுப்ப இயலவில்லை"
 
-#: src/msmtp.c:4167
+#: src/msmtp.c:4325
 #, c-format
 msgid "delivery to one or more recipients failed"
 msgstr ""
@@ -1557,16 +1562,6 @@ msgstr ""
 msgid "password for %s at %s: "
 msgstr "%2$s யில் %1$s யின் கடவுச்சொல்: "
 
-#: src/password.c:252
-#, c-format
-msgid "cannot evaluate '%s': %s"
-msgstr "'%s' யைக் கணிக்க முடியவில்லை: %s"
-
-#: src/password.c:262
-#, c-format
-msgid "cannot read output of '%s'"
-msgstr "'%s' வின் வெளியீட்டைப் படிக்க முடியவில்லை"
-
 #: src/smtp.c:208
 #, c-format
 msgid "the server sent an empty reply"
@@ -1699,6 +1694,14 @@ msgstr ""
 #, c-format
 msgid "invalid argument for Remote Message Queue Starting"
 msgstr ""
+
+#, c-format
+#~ msgid "cannot evaluate '%s': %s"
+#~ msgstr "'%s' யைக் கணிக்க முடியவில்லை: %s"
+
+#, c-format
+#~ msgid "cannot read output of '%s'"
+#~ msgstr "'%s' வின் வெளியீட்டைப் படிக்க முடியவில்லை"
 
 #, c-format
 #~ msgid "output of '%s' is longer than %d characters"

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: msmtp 1.8.18\n"
 "Report-Msgid-Bugs-To: marlam@marlam.de\n"
-"POT-Creation-Date: 2022-03-23 20:22+0100\n"
+"POT-Creation-Date: 2022-07-27 18:42+0200\n"
 "PO-Revision-Date: 2021-10-23 19:08+0300\n"
 "Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
 "Language-Team: Ukrainian <trans-uk@lists.fedoraproject.org>\n"
@@ -40,7 +40,7 @@ msgstr "рядок %d: некоректна альтернативна назв�
 msgid "line %d: duplicate alias '%s'"
 msgstr "рядок %d: дублювання альтернативної назви «%s»"
 
-#: src/aliases.c:178 src/conf.c:1072 src/stream.c:63
+#: src/aliases.c:178 src/conf.c:1193 src/stream.c:63
 #, c-format
 msgid "input error"
 msgstr "помилка у вхідних даних"
@@ -50,32 +50,32 @@ msgstr "помилка у вхідних даних"
 msgid "Too many redirects when expanding alias %s."
 msgstr "Забагато переспрямувань при розгортанні альтернативної назви %s."
 
-#: src/conf.c:808 src/conf.c:823
+#: src/conf.c:815 src/conf.c:830
 #, c-format
 msgid "host not set"
 msgstr "не вказано вузол"
 
-#: src/conf.c:813
+#: src/conf.c:820
 #, c-format
 msgid "port not set"
 msgstr "порт не встановлено"
 
-#: src/conf.c:818
+#: src/conf.c:825
 #, c-format
 msgid "envelope-from address is missing"
 msgstr "пропущено адресу-обгортку «Від» (envelope-from)"
 
-#: src/conf.c:828
+#: src/conf.c:835
 #, c-format
 msgid "tls_key_file requires tls_cert_file"
 msgstr "tls_key_file потребує визначення tls_cert_file"
 
-#: src/conf.c:833
+#: src/conf.c:840
 #, c-format
 msgid "tls_cert_file requires tls_key_file"
 msgstr "tls_cert_file потребує визначення tls_key_file"
 
-#: src/conf.c:841
+#: src/conf.c:848
 #, c-format
 msgid ""
 "tls requires either tls_trust_file (highly recommended) or tls_fingerprint "
@@ -84,73 +84,73 @@ msgstr ""
 "tls потребує встановлення tls_trust_file (наполегливо рекомендуємо) або "
 "tls_fingerprint чи вимикання tls_certcheck"
 
-#: src/conf.c:847
+#: src/conf.c:854
 #, c-format
 msgid "tls_crl_file requires tls_trust_file"
 msgstr "tls_crl_file потребує визначення tls_trust_file"
 
-#: src/conf.c:879 src/conf.c:886 src/conf.c:903 src/mtls-gnutls.c:328
+#: src/conf.c:886 src/conf.c:893 src/conf.c:910 src/mtls-gnutls.c:328
 #, c-format
 msgid "%s: %s"
 msgstr "%s: %s"
 
-#: src/conf.c:1094
-#, c-format
-msgid "line longer than %d characters"
-msgstr "довжина рядка перевищує %d символів"
-
-#: src/conf.c:1145 src/conf.c:1270
+#: src/conf.c:1119 src/conf.c:1292
 #, c-format
 msgid "line %d: missing account name"
 msgstr "рядок %d: пропущено назву облікового запису"
 
-#: src/conf.c:1150
+#: src/conf.c:1124
 #, c-format
 msgid "line %d: account %s not (yet) defined"
 msgstr "рядок %d: обліковий запис %s (ще) не визначено"
 
-#: src/conf.c:1242 src/conf.c:2060 src/conf.c:2077
+#: src/conf.c:1205
 #, c-format
-msgid "line %d: command %s does not take an argument"
-msgstr "рядок %d: команді %s не слід передавати аргументи"
+msgid "line longer than %d characters"
+msgstr "довжина рядка перевищує %d символів"
 
-#: src/conf.c:1278
-#, c-format
-msgid "line %d: an account name must not contain colons or commas"
-msgstr "рядок %d: назва облікового запису не повинна містити двокрапок і ком"
-
-#: src/conf.c:1288
-#, c-format
-msgid "line %d: account %s was already defined"
-msgstr "рядок %d: обліковий запис %s вже визначено"
-
-#: src/conf.c:1313 src/conf.c:1332 src/conf.c:1359 src/conf.c:1388
-#: src/conf.c:1695 src/conf.c:1730
+#: src/conf.c:1222 src/conf.c:1335 src/conf.c:1354 src/conf.c:1381
+#: src/conf.c:1410 src/conf.c:1718 src/conf.c:1753
 #, c-format
 msgid "line %d: command %s needs an argument"
 msgstr "рядок %d: команді %s слід передати аргумент"
 
-#: src/conf.c:1343 src/conf.c:1375 src/conf.c:1406 src/conf.c:1440
-#: src/conf.c:1466 src/conf.c:1511 src/conf.c:1531 src/conf.c:1616
-#: src/conf.c:1637 src/conf.c:1656 src/conf.c:1717 src/conf.c:1748
-#: src/conf.c:1798 src/conf.c:1845 src/conf.c:1870 src/conf.c:1890
-#: src/conf.c:1910 src/conf.c:1930 src/conf.c:1977 src/conf.c:1998
-#: src/conf.c:2019 src/conf.c:2047
+#: src/conf.c:1264 src/conf.c:2103 src/conf.c:2120
+#, c-format
+msgid "line %d: command %s does not take an argument"
+msgstr "рядок %d: команді %s не слід передавати аргументи"
+
+#: src/conf.c:1300
+#, c-format
+msgid "line %d: an account name must not contain colons or commas"
+msgstr "рядок %d: назва облікового запису не повинна містити двокрапок і ком"
+
+#: src/conf.c:1310
+#, c-format
+msgid "line %d: account %s was already defined"
+msgstr "рядок %d: обліковий запис %s вже визначено"
+
+#: src/conf.c:1365 src/conf.c:1397 src/conf.c:1428 src/conf.c:1462
+#: src/conf.c:1488 src/conf.c:1534 src/conf.c:1554 src/conf.c:1639
+#: src/conf.c:1660 src/conf.c:1679 src/conf.c:1740 src/conf.c:1771
+#: src/conf.c:1821 src/conf.c:1868 src/conf.c:1893 src/conf.c:1913
+#: src/conf.c:1933 src/conf.c:1953 src/conf.c:1973 src/conf.c:2020
+#: src/conf.c:2041 src/conf.c:2062 src/conf.c:2090
 #, c-format
 msgid "line %d: invalid argument %s for command %s"
 msgstr "рядок %d: некоректний аргумент %s команди %s"
 
-#: src/conf.c:2093
+#: src/conf.c:2136
 #, c-format
 msgid "line %d: unknown command %s"
 msgstr "рядок %d: невідома команда %s"
 
-#: src/conf.c:2145
+#: src/conf.c:2190
 #, c-format
 msgid "contains secrets and therefore must be owned by you"
 msgstr "містить конфіденційні дані, тому його власником маєте бути ви"
 
-#: src/conf.c:2151
+#: src/conf.c:2196
 #, c-format
 msgid ""
 "contains secrets and therefore must have no more than user read/write "
@@ -161,215 +161,215 @@ msgstr ""
 
 #. TRANSLATORS: msmtp shares a lot of code and translatable strings with
 #. mpop <https://marlam.de/mpop>.
-#: src/msmtp.c:88
+#: src/msmtp.c:90
 #, c-format
 msgid "%s: FATAL: %s\n"
 msgstr "%s: АВАРІЯ: %s\n"
 
-#: src/msmtp.c:228 src/msmtp.c:406 src/msmtp.c:1401
+#: src/msmtp.c:230 src/msmtp.c:408 src/msmtp.c:1522
 #, c-format
 msgid "the server does not support TLS via the STARTTLS command"
 msgstr "на сервері не передбачено підтримки TLS на основі команди STARTTLS"
 
-#: src/msmtp.c:270
+#: src/msmtp.c:272
 #, c-format
 msgid "the server does not support Remote Message Queue Starting"
 msgstr "на сервері не передбачено підтримки Remote Message Queue Starting"
 
-#: src/msmtp.c:282 src/msmtp.c:1459
+#: src/msmtp.c:284 src/msmtp.c:1580
 #, c-format
 msgid "the server does not support authentication"
 msgstr "на сервері не передбачено підтримки розпізнавання"
 
-#: src/msmtp.c:441
+#: src/msmtp.c:443
 #, c-format
 msgid "%s server at %s (%s [%s]), port %d:\n"
 msgstr "сервер %s на %s (%s [%s]), порт %d:\n"
 
-#: src/msmtp.c:447
+#: src/msmtp.c:450
 #, c-format
 msgid "%s server at %s (%s), port %d:\n"
 msgstr "сервер %s на %s (%s), порт %d:\n"
 
-#: src/msmtp.c:453
+#: src/msmtp.c:457
 #, c-format
 msgid "%s server at %s ([%s]), port %d:\n"
 msgstr "сервер %s на %s ([%s]), порт %d:\n"
 
-#: src/msmtp.c:459
+#: src/msmtp.c:464
 #, c-format
 msgid "%s server at %s, port %d:\n"
 msgstr "сервер %s на %s, порт %d:\n"
 
-#: src/msmtp.c:479
+#: src/msmtp.c:485
 #, c-format
 msgid "No special capabilities.\n"
 msgstr "Немає особливих можливостей.\n"
 
-#: src/msmtp.c:483
+#: src/msmtp.c:489
 #, c-format
 msgid "Capabilities:\n"
 msgstr "Можливості:\n"
 
-#: src/msmtp.c:487
+#: src/msmtp.c:493
 msgid "Maximum message size is "
 msgstr "Максимальний розмір повідомлення — "
 
-#: src/msmtp.c:490
+#: src/msmtp.c:496
 #, c-format
 msgid "unlimited\n"
 msgstr "без обмежень\n"
 
-#: src/msmtp.c:494
+#: src/msmtp.c:500
 #, c-format
 msgid "%ld bytes"
 msgstr "%ld байтів"
 
-#: src/msmtp.c:497
+#: src/msmtp.c:503
 #, c-format
 msgid " = %.2f MiB"
 msgstr " = %.2f МіБ"
 
-#: src/msmtp.c:502
+#: src/msmtp.c:508
 #, c-format
 msgid " = %.2f KiB"
 msgstr " = %.2f КіБ"
 
-#: src/msmtp.c:509
+#: src/msmtp.c:515
 msgid "Support for command grouping for faster transmission"
 msgstr "Підтримка групування команд для швидшого передавання даних"
 
-#: src/msmtp.c:514
+#: src/msmtp.c:520
 msgid "Support for RMQS (Remote Message Queue Starting)"
 msgstr "Підтримка RMQS (Remote Message Queue Starting)"
 
-#: src/msmtp.c:519
+#: src/msmtp.c:525
 msgid "Support for Delivery Status Notifications"
 msgstr "Підтримка сповіщень щодо доставлення"
 
-#: src/msmtp.c:529
+#: src/msmtp.c:535
 msgid "Support for TLS encryption via the STARTTLS command"
 msgstr "Підтримка шифрування TLS на основі команди STARTTLS"
 
-#: src/msmtp.c:535
+#: src/msmtp.c:541
 msgid "Supported authentication methods:"
 msgstr "Підтримувані способи розпізнавання:"
 
-#: src/msmtp.c:588
+#: src/msmtp.c:594
 #, c-format
 msgid ""
 "This server might advertise more or other capabilities when TLS is active.\n"
 msgstr "Можливості цього сервера можуть бути ширшими, якщо увімкнено TLS.\n"
 
-#: src/msmtp.c:1153 src/msmtp.c:3299
+#: src/msmtp.c:1274 src/msmtp.c:3447
 #, c-format
 msgid "cannot write mail headers to temporary file: output error"
 msgstr ""
 "не вдалося виконати запис заголовків повідомлення до тимчасового файла: "
 "помилка під час виведення даних"
 
-#: src/msmtp.c:1261
+#: src/msmtp.c:1382
 #, c-format
 msgid "input error while reading the mail"
 msgstr "помилка у вхідних даних під час читання пошти"
 
-#: src/msmtp.c:1448
+#: src/msmtp.c:1569
 #, c-format
 msgid "the server does not support DSN"
 msgstr "на сервері не передбачено підтримки DSN"
 
-#: src/msmtp.c:1597 src/msmtp.c:1616 src/msmtp.c:1668
+#: src/msmtp.c:1718 src/msmtp.c:1737 src/msmtp.c:1789
 #, c-format
 msgid "automatic configuration based on SRV records failed: %s"
 msgstr ""
 "не вдалося виконати автоматичне налаштовування на основі записів SRV: %s"
 
-#: src/msmtp.c:1598
+#: src/msmtp.c:1719
 msgid "invalid mail address"
 msgstr "некоректна поштова адреса"
 
-#: src/msmtp.c:1614
+#: src/msmtp.c:1735
 #, c-format
 msgid "no SRV records for %s or %s"
 msgstr "немає записів SRV для %s або %s"
 
-#: src/msmtp.c:1631
+#: src/msmtp.c:1752
 #, c-format
 msgid "copy this to your configuration file %s"
 msgstr "скопіюйте це до вашого файла налаштувань %s"
 
-#: src/msmtp.c:1635
+#: src/msmtp.c:1756
 msgid "warning: the host does not match the mail domain; please check"
 msgstr ""
 "попередження: вузол є невідповідним поштовому домену; будь ласка, перевірте"
 
-#: src/msmtp.c:1638 src/msmtp.c:1642
+#: src/msmtp.c:1759 src/msmtp.c:1763
 msgid "add your password to the key ring:"
 msgstr "додайте ваш пароль до сховища ключів:"
 
-#: src/msmtp.c:1645
+#: src/msmtp.c:1766
 msgid "encrypt your password:"
 msgstr "зашифруйте ваш пароль:"
 
-#: src/msmtp.c:1669
+#: src/msmtp.c:1790
 msgid "this system lacks libresolv"
 msgstr "у цій системі немає libresolv"
 
-#: src/msmtp.c:1896
+#: src/msmtp.c:2022
 #, c-format
 msgid "invalid logfile_time_format"
 msgstr "некоректне значення logfile_time_format"
 
-#: src/msmtp.c:1909
+#: src/msmtp.c:2035
 #, c-format
 msgid "cannot open: %s"
 msgstr "не вдалося відкрити: %s"
 
-#: src/msmtp.c:1917
+#: src/msmtp.c:2043
 #, c-format
 msgid "cannot lock (tried for %d seconds): %s"
 msgstr "не вдалося заблокувати (спроби виконувалися %d секунд): %s"
 
-#: src/msmtp.c:1922
+#: src/msmtp.c:2048
 #, c-format
 msgid "cannot lock: %s"
 msgstr "не вдалося заблокувати: %s"
 
-#: src/msmtp.c:1931
+#: src/msmtp.c:2057
 msgid "output error"
 msgstr "помилка виведення"
 
-#: src/msmtp.c:1948
+#: src/msmtp.c:2074
 #, c-format
 msgid "cannot log to %s: %s"
 msgstr "не вдалося записати дані журналу до %s: %s"
 
-#: src/msmtp.c:1952
+#: src/msmtp.c:2078
 #, c-format
 msgid "log info was: %s"
 msgstr "дані журналу: %s"
 
-#: src/msmtp.c:2061
+#: src/msmtp.c:2187
 #, c-format
 msgid "%s version %s\n"
 msgstr "%s, версія %s\n"
 
-#: src/msmtp.c:2062
+#: src/msmtp.c:2188
 #, c-format
 msgid "Platform: %s\n"
 msgstr "Платформа: %s\n"
 
-#: src/msmtp.c:2064
+#: src/msmtp.c:2190
 #, c-format
 msgid "TLS/SSL library: %s\n"
 msgstr "Бібліотека TLS/SSL: %s\n"
 
-#: src/msmtp.c:2072 src/msmtp.c:2150
+#: src/msmtp.c:2198 src/msmtp.c:2276
 #, c-format
 msgid "none"
 msgstr "немає"
 
-#: src/msmtp.c:2076
+#: src/msmtp.c:2202
 #, c-format
 msgid ""
 "Authentication library: %s\n"
@@ -378,65 +378,65 @@ msgstr ""
 "Бібліотека для розпізнавання: %s\n"
 "Підтримувані способи розпізнавання:\n"
 
-#: src/msmtp.c:2079
+#: src/msmtp.c:2205
 msgid "GNU SASL; oauthbearer and xoauth2: built-in"
 msgstr "GNU SASL; oauthbearer та xoauth2: вбудовані"
 
-#: src/msmtp.c:2081
+#: src/msmtp.c:2207
 msgid "built-in"
 msgstr "вбудований"
 
-#: src/msmtp.c:2130
+#: src/msmtp.c:2256
 #, c-format
 msgid "IDN support: "
 msgstr "Підтримка IDN: "
 
-#: src/msmtp.c:2134 src/msmtp.c:2142
+#: src/msmtp.c:2260 src/msmtp.c:2268
 #, c-format
 msgid "enabled"
 msgstr "увімкнено"
 
-#: src/msmtp.c:2136 src/msmtp.c:2145
+#: src/msmtp.c:2262 src/msmtp.c:2271
 #, c-format
 msgid "disabled"
 msgstr "вимкнено"
 
-#: src/msmtp.c:2140
+#: src/msmtp.c:2266
 #, c-format
 msgid "NLS: "
 msgstr "NLS: "
 
-#: src/msmtp.c:2143
+#: src/msmtp.c:2269
 #, c-format
 msgid ", LOCALEDIR is %s"
 msgstr ", LOCALEDIR %s"
 
-#: src/msmtp.c:2148
+#: src/msmtp.c:2274
 #, c-format
 msgid "Keyring support: "
 msgstr "Підтримка сховища ключів: "
 
-#: src/msmtp.c:2153
+#: src/msmtp.c:2279
 #, c-format
 msgid "Gnome "
 msgstr "GNOME "
 
-#: src/msmtp.c:2156
+#: src/msmtp.c:2282
 #, c-format
 msgid "MacOS "
 msgstr "MacOS "
 
-#: src/msmtp.c:2162
+#: src/msmtp.c:2288
 #, c-format
 msgid "System configuration file name: %s\n"
 msgstr "Назва загальносистемного файла налаштувань: %s\n"
 
-#: src/msmtp.c:2166
+#: src/msmtp.c:2292
 #, c-format
 msgid "User configuration file name: %s\n"
 msgstr "Назва файла налаштувань користувача: %s\n"
 
-#: src/msmtp.c:2169
+#: src/msmtp.c:2295
 #, c-format
 msgid ""
 "Copyright (C) %d Martin Lambers and others.\n"
@@ -452,7 +452,7 @@ msgstr ""
 "Щодо користування ним не надається ЖОДНИХ ГАРАНТІЙ, окрім передбачених "
 "законодавством.\n"
 
-#: src/msmtp.c:2186
+#: src/msmtp.c:2312
 #, c-format
 msgid ""
 "Usage:\n"
@@ -461,7 +461,7 @@ msgstr ""
 "Користування:\n"
 "\n"
 
-#: src/msmtp.c:2187
+#: src/msmtp.c:2313
 #, c-format
 msgid ""
 "Sendmail mode (default):\n"
@@ -476,7 +476,7 @@ msgstr ""
 "  Прочитати пошту зі стандартного вхідного каналу і передати її до сервера "
 "SMTP або LMTP.\n"
 
-#: src/msmtp.c:2192
+#: src/msmtp.c:2318
 #, c-format
 msgid ""
 "Configuration mode:\n"
@@ -487,7 +487,7 @@ msgstr ""
 "  %s --configure=поштова_адреса\n"
 "  створити і вивести налаштування для вказаної адреси\n"
 
-#: src/msmtp.c:2195
+#: src/msmtp.c:2321
 #, c-format
 msgid ""
 "Server information mode:\n"
@@ -498,7 +498,7 @@ msgstr ""
 "  %s [параметр...] --serverinfo\n"
 "  Вивести відомості щодо сервера.\n"
 
-#: src/msmtp.c:2198
+#: src/msmtp.c:2324
 #, c-format
 msgid ""
 "Remote Message Queue Starting mode:\n"
@@ -511,39 +511,39 @@ msgstr ""
 "  Надіслати запит Remote Message Queue Starting до сервера.\n"
 "\n"
 
-#: src/msmtp.c:2202
+#: src/msmtp.c:2328
 #, c-format
 msgid "General options:\n"
 msgstr "Загальні параметри:\n"
 
-#: src/msmtp.c:2203
+#: src/msmtp.c:2329
 #, c-format
 msgid "  --version                    print version\n"
 msgstr "  --version                    вивести дані щодо версії\n"
 
-#: src/msmtp.c:2204
+#: src/msmtp.c:2330
 #, c-format
 msgid "  --help                       print help\n"
 msgstr "  --help                       вивести додаткове повідомлення\n"
 
-#: src/msmtp.c:2205
+#: src/msmtp.c:2331
 #, c-format
 msgid "  -P, --pretend                print configuration info and exit\n"
 msgstr ""
 "  -P, --pretend                вивести дані щодо налаштування і завершити "
 "роботу\n"
 
-#: src/msmtp.c:2206
+#: src/msmtp.c:2332
 #, c-format
 msgid "  -d, --debug                  print debugging information\n"
 msgstr "  -d, --debug                  вивести діагностичну інформацію\n"
 
-#: src/msmtp.c:2207
+#: src/msmtp.c:2333
 #, c-format
 msgid "Changing the mode of operation:\n"
 msgstr "Зміна режиму роботи:\n"
 
-#: src/msmtp.c:2208
+#: src/msmtp.c:2334
 #, c-format
 msgid ""
 "  --configure=mailaddress      generate and print configuration for address\n"
@@ -551,12 +551,12 @@ msgstr ""
 "  --configure=поштова_адреса   створити і вивести налаштування для вказаної "
 "адреси\n"
 
-#: src/msmtp.c:2209
+#: src/msmtp.c:2335
 #, c-format
 msgid "  -S, --serverinfo             print information about the server\n"
 msgstr "  -S, --serverinfo             вивести відомості щодо сервера\n"
 
-#: src/msmtp.c:2210
+#: src/msmtp.c:2336
 #, c-format
 msgid ""
 "  --rmqs=host|@domain|#queue   send a Remote Message Queue Starting request\n"
@@ -564,17 +564,17 @@ msgstr ""
 "  --rmqs=вузол|@домен|#черга   надіслати запит Remote Message Queue "
 "Starting\n"
 
-#: src/msmtp.c:2211
+#: src/msmtp.c:2337
 #, c-format
 msgid "Configuration options:\n"
 msgstr "Параметри налаштовування:\n"
 
-#: src/msmtp.c:2212
+#: src/msmtp.c:2338
 #, c-format
 msgid "  -C, --file=filename          set configuration file\n"
 msgstr "  -C, --file=назва_файла       вказати файл налаштувань\n"
 
-#: src/msmtp.c:2213
+#: src/msmtp.c:2339
 #, c-format
 msgid ""
 "  -a, --account=id             use the given account instead of the account\n"
@@ -587,7 +587,7 @@ msgstr ""
 "                               параметри можна змінити за допомогою рядка "
 "команди\n"
 
-#: src/msmtp.c:2216
+#: src/msmtp.c:2342
 #, c-format
 msgid ""
 "  --host=hostname              set the server, use only command-line "
@@ -598,12 +598,12 @@ msgstr ""
 "параметри командного рядка;\n"
 "                               не використовувати дані з файла налаштувань\n"
 
-#: src/msmtp.c:2218
+#: src/msmtp.c:2344
 #, c-format
 msgid "  --port=number                set port number\n"
 msgstr "  --port=число                 вказати номер порту\n"
 
-#: src/msmtp.c:2219
+#: src/msmtp.c:2345
 #, c-format
 msgid ""
 "  --source-ip=[IP]             set/unset source ip address to bind the "
@@ -612,38 +612,38 @@ msgstr ""
 "  --source-ip=[IP]             вказати/скасувати визначення ip-адреси для "
 "прив'язування сокета\n"
 
-#: src/msmtp.c:2220
+#: src/msmtp.c:2346
 #, c-format
 msgid "  --proxy-host=[IP|hostname]   set/unset proxy\n"
 msgstr "  --proxy-host=[IP|вузол]     визначити/скасувати визначення проксі\n"
 
-#: src/msmtp.c:2221
+#: src/msmtp.c:2347
 #, c-format
 msgid "  --proxy-port=[number]        set/unset proxy port\n"
 msgstr ""
 "  --proxy-port=[число]         вказати/скасувати визначення порту проксі\n"
 
-#: src/msmtp.c:2222
+#: src/msmtp.c:2348
 #, c-format
 msgid "  --socket=[socketname]        set/unset local socket to connect to\n"
 msgstr ""
 "  --socket=[назва_сокета]      вказати/скасувати визначення сокет для "
 "з'єднання\n"
 
-#: src/msmtp.c:2223
+#: src/msmtp.c:2349
 #, c-format
 msgid "  --timeout=(off|seconds)      set/unset network timeout in seconds\n"
 msgstr ""
 "  --timeout=(off|секунди)      вказати/скасувати визначення часу очікування "
 "у секундах\n"
 
-#: src/msmtp.c:2224
+#: src/msmtp.c:2350
 #, c-format
 msgid "  --protocol=(smtp|lmtp)       use the given sub protocol\n"
 msgstr ""
 "  --protocol=(smtp|lmtp)       використати вказаний допоміжний протокол\n"
 
-#: src/msmtp.c:2225
+#: src/msmtp.c:2351
 #, c-format
 msgid ""
 "  --domain=string              set the argument of EHLO or LHLO command\n"
@@ -651,7 +651,7 @@ msgstr ""
 "  --domain=рядок               встановити аргумент для команди EHLO або "
 "LHLO\n"
 
-#: src/msmtp.c:2226
+#: src/msmtp.c:2352
 #, c-format
 msgid ""
 "  --auth[=(on|off|method)]     enable/disable authentication and optionally\n"
@@ -661,43 +661,43 @@ msgstr ""
 "потрібно,\n"
 "                               вибрати спосіб розпізнавання\n"
 
-#: src/msmtp.c:2228
+#: src/msmtp.c:2354
 #, c-format
 msgid "  --user=[username]            set/unset user name for authentication\n"
 msgstr ""
 "  --user=[користувач]          вказати/скасувати визначення користувача для "
 "розпізнавання\n"
 
-#: src/msmtp.c:2229
+#: src/msmtp.c:2355
 #, c-format
 msgid "  --passwordeval=[eval]        evaluate password for authentication\n"
 msgstr "  --passwordeval=[eval]        перевірити пароль для розпізнавання\n"
 
-#: src/msmtp.c:2230
+#: src/msmtp.c:2356
 #, c-format
 msgid "  --tls[=(on|off)]             enable/disable TLS encryption\n"
 msgstr "  --tls[=(on|off)]             увімкнути/вимкнути шифрування TLS\n"
 
-#: src/msmtp.c:2231
+#: src/msmtp.c:2357
 #, c-format
 msgid "  --tls-starttls[=(on|off)]    enable/disable STARTTLS for TLS\n"
 msgstr "  --tls-starttls[=(on|off)]    увімкнути/вимкнути STARTTLS для TLS\n"
 
-#: src/msmtp.c:2232
+#: src/msmtp.c:2358
 #, c-format
 msgid "  --tls-trust-file=[file]      set/unset trust file for TLS\n"
 msgstr ""
 "  --tls-trust-file=[файл]      вказати/скасувати визначення файла довіри для "
 "TLS\n"
 
-#: src/msmtp.c:2233
+#: src/msmtp.c:2359
 #, c-format
 msgid "  --tls-crl-file=[file]        set/unset revocation file for TLS\n"
 msgstr ""
 "  --tls-crl-file=[файл]        вказати/скасувати визначення файла "
 "відкликання для TLS\n"
 
-#: src/msmtp.c:2234
+#: src/msmtp.c:2360
 #, c-format
 msgid ""
 "  --tls-fingerprint=[f]        set/unset trusted certificate fingerprint for "
@@ -706,7 +706,7 @@ msgstr ""
 "  --tls-fingerprint=[f]        вказати/скасувати визначення відбитка "
 "надійного сертифіката для TLS\n"
 
-#: src/msmtp.c:2235
+#: src/msmtp.c:2361
 #, c-format
 msgid ""
 "  --tls-certcheck[=(on|off)]   enable/disable server certificate checks for "
@@ -715,28 +715,28 @@ msgstr ""
 "  --tls-certcheck[=(on|off)]   увімкнути/вимкнути перевірки сертифіката для "
 "TLS\n"
 
-#: src/msmtp.c:2236
+#: src/msmtp.c:2362
 #, c-format
 msgid "  --tls-key-file=[file]        set/unset private key file for TLS\n"
 msgstr ""
 "  --tls-key-file=[файл]        вказати/скасувати визначення файла закритого "
 "ключа для TLS\n"
 
-#: src/msmtp.c:2237
+#: src/msmtp.c:2363
 #, c-format
 msgid "  --tls-cert-file=[file]       set/unset private cert file for TLS\n"
 msgstr ""
 "  --tls-cert-file=[файл]        вказати/скасувати визначення файла закритого "
 "сертифіката для TLS\n"
 
-#: src/msmtp.c:2238
+#: src/msmtp.c:2364
 #, c-format
 msgid "  --tls-priorities=[prios]     set/unset TLS priorities.\n"
 msgstr ""
 "  --tls-priorities=[пріор]     вказати/скасувати визначення пріоритетностей "
 "TLS.\n"
 
-#: src/msmtp.c:2239
+#: src/msmtp.c:2365
 #, c-format
 msgid ""
 "  --tls-host-override=[host]   set/unset override for TLS host "
@@ -745,19 +745,19 @@ msgstr ""
 "  --tls-host-override=[вузол]  встановити або зняти перевизначення для "
 "перевірки вузла TLS.\n"
 
-#: src/msmtp.c:2240
+#: src/msmtp.c:2366
 #, c-format
 msgid "  --tls-min-dh-prime-bits=[b]  set/unset minimum bit size of DH prime\n"
 msgstr ""
 "  --tls-min-dh-prime-bits=[b]  встановити/скасувати визначення мінімального "
 "розміру у бітах для основи DH\n"
 
-#: src/msmtp.c:2241
+#: src/msmtp.c:2367
 #, c-format
 msgid "Options specific to sendmail mode:\n"
 msgstr "Специфічні для режиму sendmail параметри:\n"
 
-#: src/msmtp.c:2242
+#: src/msmtp.c:2368
 #, c-format
 msgid ""
 "  --auto-from[=(on|off)]       enable/disable automatic envelope-from "
@@ -766,12 +766,12 @@ msgstr ""
 "  --auto-from[=(on|off)]       увімкнути/вимкнути автоматичне додавання "
 "адрес envelope-from\n"
 
-#: src/msmtp.c:2243
+#: src/msmtp.c:2369
 #, c-format
 msgid "  -f, --from=address           set envelope from address\n"
 msgstr "  -f, --from=адреса            встановити адресу відправника\n"
 
-#: src/msmtp.c:2244
+#: src/msmtp.c:2370
 #, c-format
 msgid ""
 "  --maildomain=[domain]        set the domain for automatic envelope from\n"
@@ -780,27 +780,27 @@ msgstr ""
 "  --maildomain=[домен]         встановити домен для автоматичного додавання\n"
 "                               адрес відправника\n"
 
-#: src/msmtp.c:2246
+#: src/msmtp.c:2372
 #, c-format
 msgid "  -N, --dsn-notify=(off|cond)  set/unset DSN conditions\n"
 msgstr ""
 "  -N, --dsn-notify=(off|cond)  встановити/скасувати встановлення умов DSN\n"
 
-#: src/msmtp.c:2247
+#: src/msmtp.c:2373
 #, c-format
 msgid "  -R, --dsn-return=(off|ret)   set/unset DSN amount\n"
 msgstr ""
 "  -R, --dsn-return=(off|ret)   встановити/скасувати встановлення розміру "
 "DSN\n"
 
-#: src/msmtp.c:2248
+#: src/msmtp.c:2374
 #, c-format
 msgid "  -X, --logfile=[file]         set/unset log file\n"
 msgstr ""
 "  -X, --logfile=[файл]         встановити/скасувати встановлення файла "
 "журналу\n"
 
-#: src/msmtp.c:2249
+#: src/msmtp.c:2375
 #, c-format
 msgid ""
 "  --logfile-time-format=[fmt]  set/unset log file time format for "
@@ -809,7 +809,7 @@ msgstr ""
 "  --logfile-time-format=[фмт]  встановити/скасувати встановлення формату "
 "часу у файлі журналу для strftime()\n"
 
-#: src/msmtp.c:2250
+#: src/msmtp.c:2376
 #, c-format
 msgid ""
 "  --syslog[=(on|off|facility)] enable/disable/configure syslog logging\n"
@@ -817,38 +817,44 @@ msgstr ""
 "  --syslog[=(on|off|facility)] увімкнути/вимкнути/налаштувати ведення "
 "журналу syslog\n"
 
-#: src/msmtp.c:2251
+#: src/msmtp.c:2377
 #, c-format
 msgid ""
 "  -t, --read-recipients        read additional recipients from the mail\n"
 msgstr ""
 "  -t, --read-recipients        читати додаткові адреси відправників з пошти\n"
 
-#: src/msmtp.c:2252
+#: src/msmtp.c:2378
 #, c-format
 msgid ""
 "  --read-envelope-from         read envelope from address from the mail\n"
 msgstr "  --read-envelope-from         читати адресу відправника з пошти\n"
 
-#: src/msmtp.c:2253
+#: src/msmtp.c:2379
 #, c-format
 msgid "  --aliases=[file]             set/unset aliases file\n"
 msgstr ""
 "  --aliases=[файл]             встановити/скасувати встановлення файла "
 "псевдонімів\n"
 
-#: src/msmtp.c:2254
+#: src/msmtp.c:2380
 #, c-format
 msgid "  --set-from-header[=(auto|on|off)] set From header handling\n"
 msgstr ""
 "  --set-from-header[=(auto|on|off)] встановити обробку заголовка «Від»\n"
 
-#: src/msmtp.c:2255
+#: src/msmtp.c:2381
 #, c-format
 msgid "  --set-date-header[=(auto|off)] set Date header handling\n"
 msgstr "  --set-date-header[=(auto|off)] встановити обробку заголовка «Дата»\n"
 
-#: src/msmtp.c:2256
+#: src/msmtp.c:2382
+#, fuzzy, c-format
+#| msgid "  --set-date-header[=(auto|off)] set Date header handling\n"
+msgid "  --set-msgid-header[=(auto|off)] set Message-ID header handling\n"
+msgstr "  --set-date-header[=(auto|off)] встановити обробку заголовка «Дата»\n"
+
+#: src/msmtp.c:2383
 #, c-format
 msgid ""
 "  --remove-bcc-headers[=(on|off)] enable/disable removal of Bcc headers\n"
@@ -856,7 +862,7 @@ msgstr ""
 "  --remove-bcc-headers[=(on|off)] увімкнути/вимкнути вилучення заголовків "
 "Bcc\n"
 
-#: src/msmtp.c:2257
+#: src/msmtp.c:2384
 #, c-format
 msgid ""
 "  --undisclosed-recipients[=(on|off)] enable/disable replacement of To/Cc/"
@@ -867,12 +873,12 @@ msgstr ""
 "Bcc\n"
 "                               на To: undisclosed-recipients:;\n"
 
-#: src/msmtp.c:2259
+#: src/msmtp.c:2386
 #, c-format
 msgid "  --                           end of options\n"
 msgstr "  --                           кінець параметрів\n"
 
-#: src/msmtp.c:2260
+#: src/msmtp.c:2387
 #, c-format
 msgid ""
 "Accepted but ignored: -A, -B, -bm, -F, -G, -h, -i, -L, -m, -n, -O, -o, -v\n"
@@ -880,7 +886,7 @@ msgstr ""
 "Приймаються, але ігноруються: -A, -B, -bm, -F, -G, -h, -i, -L, -m, -n, -O, -"
 "o, -v\n"
 
-#: src/msmtp.c:2261
+#: src/msmtp.c:2388
 #, c-format
 msgid ""
 "\n"
@@ -889,237 +895,237 @@ msgstr ""
 "\n"
 "Сповіщайте про помилки на адресу <%s>.\n"
 
-#: src/msmtp.c:2503 src/msmtp.c:2517
+#: src/msmtp.c:2633 src/msmtp.c:2647
 msgid "cannot use both --serverinfo and --rmqs"
 msgstr "не можна одночасно використовувати --serverinfo і --rmqs"
 
-#: src/msmtp.c:2537 src/msmtp.c:2549
+#: src/msmtp.c:2667 src/msmtp.c:2679
 msgid "cannot use both --host and --account"
 msgstr "не можна одночасно використовувати --host і --account"
 
-#: src/msmtp.c:2565 src/msmtp.c:2583 src/msmtp.c:2602 src/msmtp.c:2657
-#: src/msmtp.c:2689 src/msmtp.c:2707 src/msmtp.c:2770 src/msmtp.c:2815
-#: src/msmtp.c:2837 src/msmtp.c:2883 src/msmtp.c:2908 src/msmtp.c:2927
-#: src/msmtp.c:2980 src/msmtp.c:3025 src/msmtp.c:3052 src/msmtp.c:3070
-#: src/msmtp.c:3089 src/msmtp.c:3108 src/msmtp.c:3126 src/msmtp.c:3144
-#: src/msmtp.c:3221
+#: src/msmtp.c:2695 src/msmtp.c:2713 src/msmtp.c:2732 src/msmtp.c:2787
+#: src/msmtp.c:2819 src/msmtp.c:2837 src/msmtp.c:2900 src/msmtp.c:2945
+#: src/msmtp.c:2967 src/msmtp.c:3013 src/msmtp.c:3038 src/msmtp.c:3057
+#: src/msmtp.c:3110 src/msmtp.c:3155 src/msmtp.c:3182 src/msmtp.c:3200
+#: src/msmtp.c:3218 src/msmtp.c:3237 src/msmtp.c:3256 src/msmtp.c:3274
+#: src/msmtp.c:3292 src/msmtp.c:3369
 #, c-format
 msgid "invalid argument %s for %s"
 msgstr "некоректний аргумент %s %s"
 
-#: src/msmtp.c:2612 src/msmtp.c:3184
+#: src/msmtp.c:2742 src/msmtp.c:3332
 msgid "cannot use both --from and --read-envelope-from"
 msgstr "не можна одночасно використовувати --from і --read-envelope-from"
 
-#: src/msmtp.c:3199
+#: src/msmtp.c:3347
 #, c-format
 msgid "unsupported operation mode b%s"
 msgstr "непідтримуваний режим роботи b%s"
 
-#: src/msmtp.c:3276 src/msmtp.c:3753 src/msmtp.c:4052
+#: src/msmtp.c:3424 src/msmtp.c:3904 src/msmtp.c:4204
 #, c-format
 msgid "cannot create temporary file: %s"
 msgstr "не вдалося створити тимчасовий файл: %s"
 
-#: src/msmtp.c:3306 src/msmtp.c:3778 src/msmtp.c:4085
+#: src/msmtp.c:3454 src/msmtp.c:3930 src/msmtp.c:4243
 #, c-format
 msgid "cannot rewind temporary file: %s"
 msgstr "не вдалося виконати гортання назад тимчасового файла: %s"
 
-#: src/msmtp.c:3371
+#: src/msmtp.c:3520
 #, c-format
 msgid "ignoring system configuration file %s: %s\n"
 msgstr "ігноруємо загальносистемний файл налаштувань %s: %s\n"
 
-#: src/msmtp.c:3386
+#: src/msmtp.c:3535
 #, c-format
 msgid "loaded system configuration file %s\n"
 msgstr "завантажено загальносистемний файл налаштувань %s\n"
 
-#: src/msmtp.c:3425
+#: src/msmtp.c:3574
 #, c-format
 msgid "ignoring user configuration file %s: %s\n"
 msgstr "ігноруємо файл налаштувань користувача %s: %s\n"
 
-#: src/msmtp.c:3440
+#: src/msmtp.c:3589
 #, c-format
 msgid "loaded user configuration file %s\n"
 msgstr "завантажено файл налаштувань користувача %s\n"
 
-#: src/msmtp.c:3497
+#: src/msmtp.c:3646
 #, c-format
 msgid "using account %s from %s\n"
 msgstr "з використанням облікового запису %s з %s\n"
 
-#: src/msmtp.c:3503 src/msmtp.c:3505 src/msmtp.c:3508 src/msmtp.c:3542
-#: src/msmtp.c:3543 src/msmtp.c:3545 src/msmtp.c:3547 src/msmtp.c:3551
-#: src/msmtp.c:3553 src/msmtp.c:3572 src/msmtp.c:3574 src/msmtp.c:3576
-#: src/msmtp.c:3586 src/msmtp.c:3589 src/msmtp.c:3591 src/msmtp.c:3596
-#: src/msmtp.c:3599 src/msmtp.c:3611 src/msmtp.c:3613 src/msmtp.c:3615
-#: src/msmtp.c:3618 src/msmtp.c:3620 src/msmtp.c:3622
+#: src/msmtp.c:3650 src/msmtp.c:3653 src/msmtp.c:3655 src/msmtp.c:3658
+#: src/msmtp.c:3692 src/msmtp.c:3693 src/msmtp.c:3695 src/msmtp.c:3697
+#: src/msmtp.c:3701 src/msmtp.c:3703 src/msmtp.c:3722 src/msmtp.c:3724
+#: src/msmtp.c:3726 src/msmtp.c:3736 src/msmtp.c:3739 src/msmtp.c:3741
+#: src/msmtp.c:3746 src/msmtp.c:3749 src/msmtp.c:3761 src/msmtp.c:3763
+#: src/msmtp.c:3765 src/msmtp.c:3768 src/msmtp.c:3770 src/msmtp.c:3772
 msgid "(not set)"
 msgstr "(не встановлено)"
 
-#: src/msmtp.c:3512
+#: src/msmtp.c:3662
 #, c-format
 msgid "off\n"
 msgstr "вимкнено\n"
 
-#: src/msmtp.c:3518
+#: src/msmtp.c:3668
 #, c-format
 msgid "%d seconds\n"
 msgstr "%d секунд\n"
 
-#: src/msmtp.c:3522
+#: src/msmtp.c:3672
 #, c-format
 msgid "1 second\n"
 msgstr "1 секунда\n"
 
-#: src/msmtp.c:3531
+#: src/msmtp.c:3681
 #, c-format
 msgid "none\n"
 msgstr "немає\n"
 
-#: src/msmtp.c:3535
+#: src/msmtp.c:3685
 #, c-format
 msgid "choose\n"
 msgstr "виберіть\n"
 
-#: src/msmtp.c:3548 src/msmtp.c:3549 src/msmtp.c:3578 src/msmtp.c:3594
-#: src/msmtp.c:3602 src/msmtp.c:3607 src/msmtp.c:3609
+#: src/msmtp.c:3698 src/msmtp.c:3699 src/msmtp.c:3728 src/msmtp.c:3744
+#: src/msmtp.c:3752 src/msmtp.c:3757 src/msmtp.c:3759
 msgid "on"
 msgstr "увімкнено"
 
-#: src/msmtp.c:3548 src/msmtp.c:3549 src/msmtp.c:3578 src/msmtp.c:3594
-#: src/msmtp.c:3602 src/msmtp.c:3605 src/msmtp.c:3607 src/msmtp.c:3609
+#: src/msmtp.c:3698 src/msmtp.c:3699 src/msmtp.c:3728 src/msmtp.c:3744
+#: src/msmtp.c:3752 src/msmtp.c:3755 src/msmtp.c:3757 src/msmtp.c:3759
 msgid "off"
 msgstr "вимкнено"
 
-#: src/msmtp.c:3599
+#: src/msmtp.c:3749
 msgid "(read from mail)"
 msgstr "(прочитано з пошти)"
 
-#: src/msmtp.c:3601 src/msmtp.c:3604
+#: src/msmtp.c:3751 src/msmtp.c:3754
 msgid "auto"
 msgstr "авто"
 
-#: src/msmtp.c:3625
+#: src/msmtp.c:3775
 #, c-format
 msgid "reading recipients from the command line and the mail\n"
 msgstr "читаємо записи отримувачів з командного рядка і пошти\n"
 
-#: src/msmtp.c:3630
+#: src/msmtp.c:3780
 #, c-format
 msgid "reading recipients from the command line\n"
 msgstr "читаємо записи отримувачів з командного рядка\n"
 
-#: src/msmtp.c:3743
+#: src/msmtp.c:3894
 msgid "too many arguments"
 msgstr "забагато аргументів"
 
-#: src/msmtp.c:3772
+#: src/msmtp.c:3924
 #, c-format
 msgid "envelope from address extracted from mail: %s\n"
 msgstr "адреса відправника, яку видобуто з пошти: %s\n"
 
-#: src/msmtp.c:3787
+#: src/msmtp.c:3939
 msgid "no recipients found"
 msgstr "не знайдено отримувачів"
 
-#: src/msmtp.c:3817
+#: src/msmtp.c:3969
 #, c-format
 msgid "account chosen by envelope from address %s: %s\n"
 msgstr "обліковий запис, який вибрано за адресою відправника %s: %s\n"
 
-#: src/msmtp.c:3831
+#: src/msmtp.c:3983
 #, c-format
 msgid "falling back to default account\n"
 msgstr "повертаємося до типового облікового запису\n"
 
-#: src/msmtp.c:3854
+#: src/msmtp.c:4006
 #, c-format
 msgid "using environment variables EMAIL and SMTPSERVER\n"
 msgstr "з використанням змінних середовища EMAIL та SMTPSERVER\n"
 
-#: src/msmtp.c:3862
+#: src/msmtp.c:4014
 #, c-format
 msgid "account %s not found in %s and %s"
 msgstr "облікового запису %s у %s та %s не знайдено"
 
-#: src/msmtp.c:3868 src/msmtp.c:3873
+#: src/msmtp.c:4020 src/msmtp.c:4025
 #, c-format
 msgid "account %s not found in %s"
 msgstr "облікового запису %s у %s не знайдено"
 
-#: src/msmtp.c:3878
+#: src/msmtp.c:4030
 #, c-format
 msgid "account %s not found: no configuration file available"
 msgstr "обліковий запис %s не знайдено: немає доступного файла налаштувань"
 
-#: src/msmtp.c:3893
+#: src/msmtp.c:4045
 #, c-format
 msgid "using account specified on command line\n"
 msgstr "з використанням облікового запису, вказаного у рядку команди\n"
 
-#: src/msmtp.c:3959
+#: src/msmtp.c:4110
 #, c-format
 msgid "account %s from %s: %s"
 msgstr "обліковий запис %s з %s: %s"
 
-#: src/msmtp.c:4000
+#: src/msmtp.c:4151
 msgid "this platform does not support syslog logging"
 msgstr "на цій платформі не передбачено підтримки ведення журналу syslog"
 
-#: src/msmtp.c:4009
+#: src/msmtp.c:4160
 #, c-format
 msgid "support for authentication method %s is not compiled in"
 msgstr ""
 "під час збирання програми не було увімкнено підтримку способу розпізнавання "
 "%s"
 
-#: src/msmtp.c:4017
+#: src/msmtp.c:4168
 #, c-format
 msgid "cannot initialize networking: %s"
 msgstr "не вдалося ініціалізувати мережу: %s"
 
-#: src/msmtp.c:4028
+#: src/msmtp.c:4179
 #, c-format
 msgid "cannot initialize TLS library: %s"
 msgstr "не вдалося ініціалізувати бібліотеку TLS: %s"
 
-#: src/msmtp.c:4035
+#: src/msmtp.c:4186
 msgid "support for TLS is not compiled in"
 msgstr "підтримку TLS не було увімкнено під час збирання програми"
 
-#: src/msmtp.c:4114
+#: src/msmtp.c:4272
 #, c-format
 msgid "LMTP server message: %s"
 msgstr "Повідомлення сервера LMTP: %s"
 
-#: src/msmtp.c:4125
+#: src/msmtp.c:4283
 #, c-format
 msgid "could not send mail to all recipients (account %s from %s)"
 msgstr "не вдалося надіслати пошту усім отримувачам (обліковий запис %s з %s)"
 
-#: src/msmtp.c:4131
+#: src/msmtp.c:4289
 msgid "could not send mail to all recipients"
 msgstr "не вдалося надіслати пошту усім отримувачам"
 
-#: src/msmtp.c:4146 src/msmtp.c:4201 src/msmtp.c:4222
+#: src/msmtp.c:4304 src/msmtp.c:4359 src/msmtp.c:4380
 #, c-format
 msgid "server message: %s"
 msgstr "повідомлення сервера: %s"
 
-#: src/msmtp.c:4152
+#: src/msmtp.c:4310
 #, c-format
 msgid "could not send mail (account %s from %s)"
 msgstr "не вдалося надіслати пошту (обліковий запис %s з %s)"
 
-#: src/msmtp.c:4157
+#: src/msmtp.c:4315
 msgid "could not send mail"
 msgstr "не вдалося надіслати пошту"
 
-#: src/msmtp.c:4167
+#: src/msmtp.c:4325
 #, c-format
 msgid "delivery to one or more recipients failed"
 msgstr "не вдалося доставити пошту до одного або декількох отримувачів"
@@ -1650,16 +1656,6 @@ msgstr "не вдалося з'єднатися із %s, порт %d: %s"
 msgid "password for %s at %s: "
 msgstr "пароль до %s на %s: "
 
-#: src/password.c:252
-#, c-format
-msgid "cannot evaluate '%s': %s"
-msgstr "не вдалося визначити «%s»: %s"
-
-#: src/password.c:262
-#, c-format
-msgid "cannot read output of '%s'"
-msgstr "не вдалося прочитати дані, які виведено «%s»"
-
 #: src/smtp.c:208
 #, c-format
 msgid "the server sent an empty reply"
@@ -1795,6 +1791,14 @@ msgstr "серверу не вдалося виконати запит"
 #, c-format
 msgid "invalid argument for Remote Message Queue Starting"
 msgstr "некоректний аргумент Remote Message Queue Starting"
+
+#, c-format
+#~ msgid "cannot evaluate '%s': %s"
+#~ msgstr "не вдалося визначити «%s»: %s"
+
+#, c-format
+#~ msgid "cannot read output of '%s'"
+#~ msgstr "не вдалося прочитати дані, які виведено «%s»"
 
 #~ msgid "Common Name"
 #~ msgstr "Звичайне ім'я"

--- a/scripts/msmtpq/README.msmtpq
+++ b/scripts/msmtpq/README.msmtpq
@@ -55,7 +55,7 @@ from msmtpq
 Configuration :
 -------------
 
-all config is done within the msmtpq script
+all config is done by exporting these environment variables
 
   set the MSMTP var to point to the location of the msmtp executable
     (set this only if necessary ; if it's not on the path)
@@ -68,15 +68,12 @@ circumstances, such as embedded systems, etc. ; otherwise, if you are
 running a normal Linux distribution you can leave it as is ; msmtp will
 by default be on the execution path
 
-the Q variable should have the location of the queue directory
+the Q variable should have the location of the queue directory ; please
+note that it's preferable to create the queue directory (with 0700
+permissions) before using these routines
 
-the LOG variable should have the desired name & location of the queue log
-
-the locations are clearly marked near the beginning of the script ;
-modify all to the locations you prefer (the defaults work for me ; you
-may or may not be happy with them) ... please note that it's preferable
-to create the queue directory (with 0700 permissions) before using these
-routines
+the LOG variable should have the desired name & location of the queue
+log ; set it to an empty string (export LOG="") to disable logging
 
 note that the default msmtpq set up creates a separate log for queue
 operations ; all operations which modify the queue in any way are logged
@@ -85,9 +82,9 @@ to the queue log ; this is distinct from the msmtp log set by the
 have separate logs (for the distinct functions) ; if this doesn't sit
 well with you it's possible to define the queue log to be the same log
 file as the one defined in .msmtprc ; it's also possible to turn off
-queue logging entirely (by commenting out the 'LOG=' var - to be
-'#LOG=') but this seems hardly advisable, particularly before you are
-confident that all is working
+queue logging entirely (by setting LOG to an empty string -
+export LOG="" ) but this seems hardly advisable, particularly before
+you are confident that all is working
 
 mutt users please take note of the additional setup instructions in the
 msmtp docs & man page.

--- a/scripts/msmtpq/msmtpq
+++ b/scripts/msmtpq/msmtpq
@@ -72,7 +72,7 @@ fi
 ##
 ## the queue dir - export this variable to reflect where you'd like it to be  (no quotes !!)
 Q=${Q:-~/.msmtp.queue}
-[ -d "$Q" ] || mkdir -m 0700 "$Q" || \
+[ -d "$Q" ] || mkdir -m 0700 -p "$Q" || \
   err '' "msmtpq : can't find or create msmtp queue directory [ $Q ]" ''     # if not present - complain ; quit
 ##
 ## set the queue log file var to the location of the msmtp queue log file
@@ -86,6 +86,7 @@ Q=${Q:-~/.msmtp.queue}
 ## the queue log file - export this variable to change where logs are stored  (but no quotes !!)
 ##                      Set it to "" (empty string) to disable logging.
 [ -v LOG ] || LOG=~/log/msmtp.queue.log
+[ -d "$(dirname "$LOG")" ] || mkdir -p "$(dirname "$LOG")"
 ## ======================================================================================
 
 ## msmtpq can use the following environment variables :

--- a/scripts/msmtpq/msmtpq
+++ b/scripts/msmtpq/msmtpq
@@ -56,12 +56,13 @@ err() { dsp '' "$@" '' ; exit 1 ; }
 ## ======================================================================================
 ##
 ## only if necessary (in unusual circumstances - e.g. embedded systems),
-##   enter the location of the msmtp executable  (no quotes !!)
-##   e.g. ( MSMTP=/path/to/msmtp )
-##   and uncomment the test for its existence
-MSMTP=msmtp
-#[ -x "$MSMTP" ] || \
-#  log -e 1 "msmtpq : can't find the msmtp executable [ $MSMTP ]"   # if not found - complain ; quit
+##   export the location of the msmtp executable before running this script  (no quotes !!)
+##   e.g. ( export MSMTP=/path/to/msmtp )
+if [ "$MSMTP" = "" ] ; then  # If MSMTP is unset or empty...
+  MSMTP=msmtp
+elif [ ! -x "$MSMTP" ] ; then
+  log -e 1 "msmtpq : can't find the msmtp executable [ $MSMTP ]"   # if not found - complain ; quit
+fi
 ##
 ## set the queue var to the location of the msmtp queue directory
 ##   if the queue dir doesn't yet exist, create it (0700)
@@ -69,8 +70,8 @@ MSMTP=msmtp
 ##       e.g. ( mkdir msmtp.queue      )
 ##            ( chmod 0700 msmtp.queue )
 ##
-## the queue dir - modify this to reflect where you'd like it to be  (no quotes !!)
-Q=~/.msmtp.queue
+## the queue dir - export this variable to reflect where you'd like it to be  (no quotes !!)
+Q=${Q:-~/.msmtp.queue}
 [ -d "$Q" ] || mkdir -m 0700 "$Q" || \
   err '' "msmtpq : can't find or create msmtp queue directory [ $Q ]" ''     # if not present - complain ; quit
 ##
@@ -79,12 +80,12 @@ Q=~/.msmtp.queue
 ##     ( note that the LOG setting could be the same as the )
 ##     ( 'logfile' setting in .msmtprc - but there may be   )
 ##     ( some advantage in keeping the two logs separate    )
-##   if you don't want the log at all unset (comment out) this var
-##     LOG=~/log/msmtp.queue.log  -->  #LOG=~/log/msmtp.queue.log
+##   if you don't want the log at all set the var to an empty string
 ##     (doing so would be inadvisable under most conditions, however)
 ##
-## the queue log file - modify (or comment out) to taste  (but no quotes !!)
-LOG=~/log/msmtp.queue.log
+## the queue log file - export this variable to change where logs are stored  (but no quotes !!)
+##                      Set it to "" (empty string) to disable logging.
+[ -v LOG ] || LOG=~/log/msmtp.queue.log
 ## ======================================================================================
 
 ## msmtpq can use the following environment variables :


### PR DESCRIPTION
There’s [pull request that was submitted to the nixpkgs repo](https://github.com/NixOS/nixpkgs/pull/185343) that contains a patch for `msmtpq`. I thought that some of the changes in that patch would be useful to people who don’t use nixpkgs, so I’m submitting them upstream.

At the moment, GitHub says that this PR would add 7 commits. In reality it would only add 2. The other 5 are in [the upstream repo](https://git.marlam.de/gitweb/?p=msmtp.git), but not on GitHub yet.