### PR TITLE
msmtpq: always test the value of `MSMTP`

### DIFF
--- a/scripts/msmtpq/msmtpq
+++ b/scripts/msmtpq/msmtpq
@@ -58,11 +58,9 @@ err() { dsp '' "$@" '' ; exit 1 ; }
 ## only if necessary (in unusual circumstances - e.g. embedded systems),
 ##   export the location of the msmtp executable before running this script  (no quotes !!)
 ##   e.g. ( export MSMTP=/path/to/msmtp )
-if [ "$MSMTP" = "" ] ; then  # If MSMTP is unset or empty...
-  MSMTP=msmtp
-elif [ ! -x "$MSMTP" ] ; then
-  log -e 1 "msmtpq : can't find the msmtp executable [ $MSMTP ]"   # if not found - complain ; quit
-fi
+MSMTP=${MSMTP:-msmtp}
+"$MSMTP" --version >/dev/null 2>&1 || \
+  log -e 1 "msmtpq : can't run the msmtp executable [ $MSMTP ]"   # if not found - complain ; quit
 ##
 ## set the queue var to the location of the msmtp queue directory
 ##   if the queue dir doesn't yet exist, create it (0700)


### PR DESCRIPTION
Before this change, `msmtpq` would only make sure that `$MSMTP` was valid if
the user had customized it. Even if `MSMTP` is left at its default value,
it’s still a good idea to make sure that the default value is valid.

This change was suggested by Peter Hoeg:
<https://github.com/marlam/msmtp-mirror/pull/86#issuecomment-1208742887>