### PR TITLE
msmtpq: don’t use `log()` before it’s defined

### DIFF
--- a/scripts/msmtpq/msmtpq
+++ b/scripts/msmtpq/msmtpq
@@ -47,6 +47,7 @@
 ##--------------------------------------------------------------
 
 
+log_later() { LOG_LATER_ARGS=( "$@" ) ; }
 dsp() { local L ; for L ; do [ -n "$L" ] && echo "  $L" || echo ; done ; }
 err() { dsp '' "$@" '' ; exit 1 ; }
 
@@ -60,7 +61,7 @@ err() { dsp '' "$@" '' ; exit 1 ; }
 ##   e.g. ( export MSMTP=/path/to/msmtp )
 MSMTP=${MSMTP:-msmtp}
 "$MSMTP" --version >/dev/null 2>&1 || \
-  log -e 1 "msmtpq : can't run the msmtp executable [ $MSMTP ]"   # if not found - complain ; quit
+  log_later -e 1 "msmtpq : can't run the msmtp executable [ $MSMTP ]"   # if not found - complain ; quit
 ##
 ## set the queue var to the location of the msmtp queue directory
 ##   if the queue dir doesn't yet exist, create it (0700)
@@ -528,6 +529,7 @@ send_mail() {    # <-- all mail args ; mail text via TMP
 ## -- entry point
 #
 
+[ -v LOG_LATER_ARGS ] && log "${LOG_LATER_ARGS[@]}"
 if [ ! "$1" = '--q-mgmt' ] ; then    # msmtpq - sendmail mode
   lock_queue                         # lock here
   make_id                            # make base queue filename id for this mail


### PR DESCRIPTION
To fix this bug, I created a new function called `log_later()`. I also considered moving the function definition for `log()` to before the variable declarations, moving the variable declarations to underneath the function declarations and moving the `"$MSMTP" --version` to the script’s “entry point”. In the end I decided to create `log_later()` in order to stay consistent with how the script was already written.

Fixes #93.