### PR TITLE
Remove stray text in msmtp man page copied from info page

### DIFF
--- a/doc/msmtp.1
+++ b/doc/msmtp.1
@@ -342,8 +342,6 @@ Use this command to set the argument of the SMTP EHLO (or LMTP LHLO) command,
 and the domain part of Message-ID headers if msmtp generates them (see the
 \fBset_msgid_header\fP command).
 .br
-The default value @samp{localhost} is stupid but usually works for EHLO. However
-it does not make sense for Message-ID headers. @xref{set_msgid_header} for details.@*
 The default value \fIlocalhost\fP is stupid but usually works for EHLO. However
 it does not make sense for Message-ID headers. See the \fBset_msgid_header\fP command
 for details.


### PR DESCRIPTION
This looks like a copy & paste error from the equivalent text in the texi file.